### PR TITLE
Add CPU/Memory limits to projects

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -28,6 +28,17 @@ const podTemplate = {
     spec: {
         containers: [
             {
+                resources: {
+                    request: {
+                        // 10th of a core
+                        cpu: "100m",
+                        memory: "128Mi"
+                    },
+                    limits: {
+                        cpu: "125m",
+                        memory: "192Mi"
+                    }
+                },
                 name: 'node-red',
                 // image: "docker-pi.local:5000/bronze-node-red",
                 env: [
@@ -38,7 +49,11 @@ const podTemplate = {
                     { name: 'web', containerPort: 1880, protocol: 'TCP' }
                 ]
             }
-        ]
+        ],
+        nodeSelector: {
+            role: "projects"
+        }
+
     },
     enableServiceLinks: false
 }


### PR DESCRIPTION
Currently set to 0.1 (up to 0.125) of a CPU and 128mi (+ 64mi extra) memory.

Open to increasing the memory and CPU based on monitoring and constraints of underlying K8s nodes. Also possibly based on template selection.

Also bound Projects to specific nodes (those labelled with `role=projects`)