### PR TITLE
Restart missing projects

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -160,6 +160,65 @@ const ingressTemplate = {
     }
 }
 
+const createPod = async (project, options) => {
+    console.log('creating ', project.name, options)
+    const localPod = JSON.parse(JSON.stringify(podTemplate))
+    localPod.metadata.name = project.name
+    localPod.metadata.labels.name = project.name
+    localPod.metadata.labels.app = project.id
+    localPod.spec.containers[0].image = `${this._options.registry}flowforge/node-red` // this._options.containers[project.type];
+    if (options.env) {
+        Object.keys(options.env).forEach(k => {
+            if (k) {
+                localPod.spec.containers[0].env.push({
+                    name: k,
+                    value: options.env[k]
+                })
+            }
+        })
+    }
+
+    const baseURL = new URL(this._app.config.base_url)
+    const projectURL = `${baseURL.protocol}//${project.name}.${this._options.domain}`
+
+    const authTokens = await project.refreshAuthTokens()
+
+    localPod.spec.containers[0].env.push({ name: 'FORGE_CLIENT_ID', value: authTokens.clientID })
+    localPod.spec.containers[0].env.push({ name: 'FORGE_CLIENT_SECRET', value: authTokens.clientSecret })
+    localPod.spec.containers[0].env.push({ name: 'FORGE_URL', value: this._app.config.api_url })
+    localPod.spec.containers[0].env.push({ name: 'BASE_URL', value: projectURL })
+    localPod.spec.containers[0].env.push({ name: 'FORGE_PROJECT_ID', value: project.id })
+    localPod.spec.containers[0].env.push({ name: 'FORGE_PROJECT_TOKEN', value: authTokens.token })
+
+    const localService = JSON.parse(JSON.stringify(serviceTemplate))
+    localService.metadata.name = project.name
+    localService.spec.selector.name = project.name
+
+    const localIngress = JSON.parse(JSON.stringify(ingressTemplate))
+    localIngress.metadata.name = project.name
+    localIngress.spec.rules[0].host = project.name + '.' + this._options.domain
+    localIngress.spec.rules[0].http.paths[0].backend.service.name = project.name
+
+    try {
+        await this._k8sApi.createNamespacedPod('flowforge', localPod)
+        await this._k8sApi.createNamespacedService('flowforge', localService)
+        await this._k8sNetApi.createNamespacedIngress('flowforge', localIngress)
+    } catch (err) {
+        console.log(err)
+        return { error: err }
+    }
+
+    project.url = projectURL
+    await project.save()
+
+    return {
+        id: project.id,
+        status: 'okay',
+        url: projectURL,
+        meta: {}
+    }
+}
+
 module.exports = {
     /**
    * Initialises this driver
@@ -192,15 +251,21 @@ module.exports = {
         this._k8sAppApi = kc.makeApiClient(k8s.AppsV1Api)
         this._k8sNetApi = kc.makeApiClient(k8s.NetworkingV1Api)
 
-
-        const projects = await this._app.db.models.Project.findAll()
+        const projects = await this._app.db.models.Project.findAll({
+            include: [
+                {
+                    model: this._app.db.models.ProjectStack
+                }
+            ]
+        })
         projects.forEach(async (project)=>{
             if (project.state === 'running') {
                 try {
                     await this._k8sApi.readNamespacedPodStatus(project.name, 'flowforge')
                 } catch (err) {
                     console.log(err.response.body)
-                    this.create(project, {env: JSON.parse(project.getSetting('environmentVariables'))})
+                    const envVars =  await project.getSetting('environmentVariables')
+                    await createPod(project, {env: JSON.parse( envVars ? envVars: '{}' )})
                 }
             }
         })
@@ -237,70 +302,7 @@ module.exports = {
    * @return {forge.containers.Project}
    */
     create: async (project, options) => {
-        console.log('creating ', project.name, options)
-        const stack = project.ProjectStack.properties
-        const localPod = JSON.parse(JSON.stringify(podTemplate))
-        localPod.metadata.name = project.name
-        localPod.metadata.labels.name = project.name
-        localPod.metadata.labels.app = project.id
-        // localPod.spec.containers[0].image = `${this._options.registry}flowforge/node-red` // this._options.containers[project.type];
-        localPod.spec.containers[0].image = stack.container
-        if (options.env) {
-            Object.keys(options.env).forEach(k => {
-                if (k) {
-                    localPod.spec.containers[0].env.push({
-                        name: k,
-                        value: options.env[k]
-                    })
-                }
-            })
-            project.updateSetting('environmentVariables', JSON.stringify(options.env))
-        }
-
-        const baseURL = new URL(this._app.config.base_url)
-        const projectURL = `${baseURL.protocol}//${project.name}.${this._options.domain}`
-
-        const authTokens = await project.refreshAuthTokens()
-
-        localPod.spec.containers[0].env.push({ name: 'FORGE_CLIENT_ID', value: authTokens.clientID })
-        localPod.spec.containers[0].env.push({ name: 'FORGE_CLIENT_SECRET', value: authTokens.clientSecret })
-        localPod.spec.containers[0].env.push({ name: 'FORGE_URL', value: this._app.config.api_url })
-        localPod.spec.containers[0].env.push({ name: 'BASE_URL', value: projectURL })
-        localPod.spec.containers[0].env.push({ name: 'FORGE_PROJECT_ID', value: project.id })
-        localPod.spec.containers[0].env.push({ name: 'FORGE_PROJECT_TOKEN', value: authTokens.token })
-
-        localPod.spec.containers[0].resources.request.memory = `${stack.memory}Mi`
-        localPod.spec.containers[0].resources.limit.memory = `${stack.memory}Mi`
-        localPod.spec.containers[0].resources.request.cpu = `${stack.cpu * 10}m`
-        localPod.spec.containers[0].resources.limit.cpu = `${stack.cpu * 10}m`
-
-        const localService = JSON.parse(JSON.stringify(serviceTemplate))
-        localService.metadata.name = project.name
-        localService.spec.selector.name = project.name
-
-        const localIngress = JSON.parse(JSON.stringify(ingressTemplate))
-        localIngress.metadata.name = project.name
-        localIngress.spec.rules[0].host = project.name + '.' + this._options.domain
-        localIngress.spec.rules[0].http.paths[0].backend.service.name = project.name
-
-        try {
-            await this._k8sApi.createNamespacedPod('flowforge', localPod)
-            await this._k8sApi.createNamespacedService('flowforge', localService)
-            await this._k8sNetApi.createNamespacedIngress('flowforge', localIngress)
-        } catch (err) {
-            console.log(err)
-            return { error: err }
-        }
-
-        project.url = projectURL
-        await project.save()
-
-        return {
-            id: project.id,
-            status: 'okay',
-            url: projectURL,
-            meta: {}
-        }
+        return await createPod(project, options)
     },
     /**
    * Removes a Project


### PR DESCRIPTION
Walks the list of projects and starts any that don't have a pod.

This should stand up any missing following an outage of the management app.

In Draft while I test it.