### PR TITLE
Fix typo in pod limits

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -197,9 +197,9 @@ const createPod = async (project, options) => {
 
     if (stack.memory && stack.cpu) {
         localPod.spec.containers[0].resources.request.memory = `${stack.memory}Mi`
-        localPod.spec.containers[0].resources.limit.memory = `${stack.memory}Mi`
+        localPod.spec.containers[0].resources.limits.memory = `${stack.memory}Mi`
         localPod.spec.containers[0].resources.request.cpu = `${stack.cpu * 10}m`
-        localPod.spec.containers[0].resources.limit.cpu = `${stack.cpu * 10}m`
+        localPod.spec.containers[0].resources.limits.cpu = `${stack.cpu * 10}m`
     }
 
     const localService = JSON.parse(JSON.stringify(serviceTemplate))


### PR DESCRIPTION
Missing `s` in pod limits definition