### PR TITLE
Throw proper errors when actions performed on unknown project

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -455,6 +455,9 @@ module.exports = {
      * @return {Object}
      */
     details: async (project) => {
+        if (this._projects[project.id] === undefined) {
+            return { state: 'unknown' }
+        }
         if (this._projects[project.id].state === 'suspended') {
             // We should only poll the launcher if we think it is running.
             // Otherwise, return our cached state
@@ -515,6 +518,9 @@ module.exports = {
      * @return {forge.Status}
      */
     startFlows: async (project) => {
+        if (this._projects[project.id] === undefined) {
+            return { state: 'unknown' }
+        }
         await got.post(`http://${project.name}.${this._namespace}:2880/flowforge/command`, {
             json: {
                 cmd: 'start'
@@ -529,6 +535,9 @@ module.exports = {
      * @return {forge.Status}
      */
     stopFlows: async (project) => {
+        if (this._projects[project.id] === undefined) {
+            return { state: 'unknown' }
+        }
         await got.post(`http://${project.name}.${this._namespace}:2880/flowforge/command`, {
             json: {
                 cmd: 'stop'
@@ -543,13 +552,11 @@ module.exports = {
      * @return {array} logs
      */
     logs: async (project) => {
-        try {
-            const result = await got.get(`http://${project.name}.${this._namespace}:2880/flowforge/logs`).json()
-            return result
-        } catch (err) {
-            console.log(err)
-            return ''
+        if (this._projects[project.id] === undefined) {
+            return { state: 'unknown' }
         }
+        const result = await got.get(`http://${project.name}.${this._namespace}:2880/flowforge/logs`).json()
+        return result
     },
 
     /**
@@ -558,6 +565,9 @@ module.exports = {
      * @return {forge.Status}
      */
     restartFlows: async (project) => {
+        if (this._projects[project.id] === undefined) {
+            return { state: 'unknown' }
+        }
         await got.post(`http://${project.name}.${this._namespace}:2880/flowforge/command`, {
             json: {
                 cmd: 'restart'


### PR DESCRIPTION
This adds proper error handling in the case where the platform asks the driver to perform actions on a project it doesn't know about. That state should not be possible to get into, but https://github.com/flowforge/flowforge/issues/612 revealed a case where it was possible (although https://github.com/flowforge/flowforge/pull/663 should plug that gap).