### PR TITLE
Improve project status & detail reporting to frontend

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -499,7 +499,7 @@ module.exports = {
                 return {
                     id: project.id,
                     state: 'starting',
-                    meta: podDetails.body.status
+                    meta: {}//podDetails.body.status
                 }
             } else if (podDetails.body.status?.phase === 'Running') {
                 const infoURL = `http://${prefix}${project.safeName}.${this._namespace}:2880/flowforge/info`
@@ -516,7 +516,7 @@ module.exports = {
                     id: project.id,
                     state: 'starting',
                     error: `Unexpected pod status '${podDetails.body.status?.phase}'`,
-                    meta: podDetails.body.status
+                    meta: {} //podDetails.body.status
                 }
             }
         } catch (err) {
@@ -525,7 +525,7 @@ module.exports = {
             return {
                 id: project?.id,
                 error: err,
-                state: 'unknown',
+                state: 'starting',
                 meta: podDetails?.body?.status
             }
         }

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -476,6 +476,7 @@ module.exports = {
      */
     details: async (project) => {
         if (this._projects[project.id] === undefined) {
+	    console.log('NO LOCAL STATE!')
             return { state: 'unknown' }
         }
         if (this._projects[project.id].state === 'suspended') {

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -514,7 +514,7 @@ module.exports = {
             } else {
                 return {
                     id: project.id,
-                    state: 'unknown',
+                    state: 'starting',
                     error: `Unexpected pod status '${podDetails.body.status?.phase}'`,
                     meta: podDetails.body.status
                 }

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -499,7 +499,7 @@ module.exports = {
                 return {
                     id: project.id,
                     state: 'starting',
-                    meta: {}//podDetails.body.status
+                    meta: {}
                 }
             } else if (podDetails.body.status?.phase === 'Running') {
                 const infoURL = `http://${prefix}${project.safeName}.${this._namespace}:2880/flowforge/info`
@@ -513,14 +513,14 @@ module.exports = {
                         id: project.id,
                         state: 'starting',
                         meta: {}
-		    }
+                    }
                 }
             } else {
                 return {
                     id: project.id,
                     state: 'starting',
                     error: `Unexpected pod status '${podDetails.body.status?.phase}'`,
-                    meta: {} //podDetails.body.status
+                    meta: {}
                 }
             }
         } catch (err) {

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -476,7 +476,6 @@ module.exports = {
      */
     details: async (project) => {
         if (this._projects[project.id] === undefined) {
-	    console.log('NO LOCAL STATE!')
             return { state: 'unknown' }
         }
         if (this._projects[project.id].state === 'suspended') {
@@ -510,7 +509,11 @@ module.exports = {
                     return info
                 } catch (err) {
                     this._app.log.debug(`error getting state from project ${project.id}: ${err}`)
-                    return
+                    return {
+                        id: project.id,
+                        state: 'starting',
+                        meta: {}
+		    }
                 }
             } else {
                 return {


### PR DESCRIPTION
part of [When a project is started/restarted launcher details not populated#990](https://github.com/flowforge/flowforge/issues/990)

related:  [Npm install starting #75](https://github.com/flowforge/flowforge-nr-launcher/pull/75)


Align operations with localfs and docker drivers by removing the direct status polling to node-red and instead, only use the `flowforge/info` for polling status

