### PR TITLE
Pod to deployment gradual

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -619,8 +619,11 @@ module.exports = {
                                 this._app.log.error(`[k8s] failed to upgrade ${project.id} to deployment`)
                                 // console.log(err)
                             })
+                        // it's just been created, not need to check if it still exists
+                        return
                     } catch (err) {
                         // bare pod not found can move on
+                        this._app.log.info(`[k8s] ${project.id} in ${namespace} is not bare pod`)
                     }
 
                     // look for missing projects
@@ -628,13 +631,14 @@ module.exports = {
                     try {
                         this._app.log.info(`[k8s] Testing ${project.id} in ${namespace} deployment exists`)
                         await this._k8sAppApi.readNamespacedDeploymentStatus(project.safeName, namespace)
-                        this._app.log.info(`[k8s] deployment ${project.id} found`)
+                        this._app.log.info(`[k8s] deployment ${project.id} in ${namespace} found`)
                     } catch (err) {
+                        console.log(`failed to read deployment for ${project.safeName}`)
                         console.log(err)
                         this._app.log.debug(`[k8s] Project ${project.id} - recreating deployment`)
                         const fullProject = await this._app.db.models.Project.byId(project.id)
                         // await createPod(fullProject)
-                        await createProject(fullProject, options)
+                        // await createProject(fullProject, options)
                     }
                 } catch (err) {
                     this._app.log.error(`[k8s] Project ${project.id} - error resuming project: ${err.stack}`)

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -609,8 +609,8 @@ module.exports = {
                         // should only get here is a bare pod exists
                         this._app.log.info(`[k8s] upgrading ${project.id} to deployment`)
                         const fullProject = await this._app.db.models.Project.byId(project.id)
-                        const localDeployment = createDeployment(fullProject, options)
-                        this._k8sAppApi.createNamespacedDeployment(localDeployment, namespace)
+                        const localDeployment = await createDeployment(fullProject, options)
+                        this._k8sAppApi.createNamespacedDeployment(namespace, localDeployment)
                             .then(() => {
                                 return this._k8sApi.deleteNamespacedPod(project.safeName, namespace)
                             })

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -248,78 +248,10 @@ const createDeployment = async (project, options) => {
         localPod.spec.containers[0].resources.limits.cpu = `${stack.cpu * 10}m`
     }
 
-    // const prefix = project.safeName.match(/^[0-9]/) ? 'srv-' : ''
-
-    // const localService = JSON.parse(JSON.stringify(serviceTemplate))
-    // localService.metadata.name = `${prefix}${project.safeName}`
-    // localService.spec.selector.name = project.safeName
-
-    // const localIngress = JSON.parse(JSON.stringify(ingressTemplate))
-    // localIngress.metadata.name = project.safeName
-    // localIngress.spec.rules[0].host = project.safeName + '.' + this._options.domain
-    // localIngress.spec.rules[0].http.paths[0].backend.service.name = `${prefix}${project.safeName}`
-
-    // if (process.env.FLOWFORGE_CLOUD_PROVIDER === 'aws' || this._app.config.driver.options.cloudProvider === 'aws') {
-    //     localIngress.metadata.annotations = {
-    //         'kubernetes.io/ingress.class': 'alb',
-    //         'alb.ingress.kubernetes.io/scheme': 'internet-facing',
-    //         'alb.ingress.kubernetes.io/target-type': 'ip',
-    //         'alb.ingress.kubernetes.io/group.name': 'flowforge',
-    //         'alb.ingress.kubernetes.io/listen-ports': '[{"HTTPS":443}, {"HTTP":80}]'
-    //     }
-    // }
-
     project.url = projectURL
     await project.save()
 
     return localDeployment
-
-    // const promises = []
-    // promises.push(this._k8sAppApi.createNamespacedDeployment(namespace, localDeployment).catch(err => {
-    //     console.log(err)
-    //     this._app.log.error(`[k8s] Project ${project.id} - error creating deployment: ${err.toString()}`)
-    //     // rethrow the error so the wrapper knows this hasn't worked
-    //     throw err
-    // }))
-    // // promises.push(this._k8sApi.createNamespacedPod(namespace, localPod).catch(err => {
-    // //     console.log(err)
-    // //     this._app.log.error(`[k8s] Project ${project.id} - error creating pod: ${err.toString()}`)
-    // //     // rethrow the error so the wrapper knows this hasn't worked
-    // //     throw err
-    // // }))
-    // /* eslint n/handle-callback-err: "off" */
-    // promises.push(this._k8sApi.createNamespacedService(namespace, localService).catch(err => {
-    //     // TODO: This will fail if the service already exists. Which it okay if
-    //     // we're restarting a suspended project. As we don't know if we're restarting
-    //     // or not, we don't know if this is fatal or not.
-
-    //     // Once we can know if this is a restart or create, then we can decide
-    //     // whether to throw this error or not. For now, this will silently
-    //     // let it pass
-    //     //
-    //     // this._app.log.error(`[k8s] Project ${project.id} - error creating service: ${err.toString()}`)
-    //     // throw err
-    // }))
-
-    // promises.push(this._k8sNetApi.createNamespacedIngress(namespace, localIngress).catch(err => {
-    //     // TODO: This will fail if the service already exists. Which it okay if
-    //     // we're restarting a suspended project. As we don't know if we're restarting
-    //     // or not, we don't know if this is fatal or not.
-
-    //     // Once we can know if this is a restart or create, then we can decide
-    //     // whether to throw this error or not. For now, this will silently
-    //     // let it pass
-    //     //
-    //     // this._app.log.error(`[k8s] Project ${project.id} - error creating ingress: ${err.toString()}`)
-    //     // throw err
-    // }))
-
-    // return Promise.all(promises).then(async () => {
-    //     this._app.log.debug(`[k8s] Container ${project.id} started`)
-    //     project.state = 'running'
-    //     await project.save()
-    //     this._projects[project.id].state = 'starting'
-    // })
 }
 
 const createService = async (project, options) => {
@@ -361,17 +293,10 @@ const createProject = async (project, options) => {
 
     const promises = []
     promises.push(this._k8sAppApi.createNamespacedDeployment(namespace, localDeployment).catch(err => {
-        console.log(err)
         this._app.log.error(`[k8s] Project ${project.id} - error creating deployment: ${err.toString()}`)
         // rethrow the error so the wrapper knows this hasn't worked
         throw err
     }))
-    // promises.push(this._k8sApi.createNamespacedPod(namespace, localPod).catch(err => {
-    //     console.log(err)
-    //     this._app.log.error(`[k8s] Project ${project.id} - error creating pod: ${err.toString()}`)
-    //     // rethrow the error so the wrapper knows this hasn't worked
-    //     throw err
-    // }))
     /* eslint n/handle-callback-err: "off" */
     promises.push(this._k8sApi.createNamespacedService(namespace, localService).catch(err => {
         // TODO: This will fail if the service already exists. Which it okay if
@@ -407,8 +332,8 @@ const createProject = async (project, options) => {
     })
 }
 
+// eslint-disable-next-line no-unused-vars
 const createPod = async (project, options) => {
-    console.log('creating ', project.name, options)
     // const namespace = this._app.config.driver.options.projectNamespace || 'flowforge'
     const stack = project.ProjectStack.properties
 
@@ -470,72 +395,10 @@ const createPod = async (project, options) => {
         localPod.spec.containers[0].resources.limits.cpu = `${stack.cpu * 10}m`
     }
 
-    // const prefix = project.safeName.match(/^[0-9]/) ? 'srv-' : ''
-
-    // const localService = JSON.parse(JSON.stringify(serviceTemplate))
-    // localService.metadata.name = `${prefix}${project.safeName}`
-    // localService.spec.selector.name = project.safeName
-
-    // const localIngress = JSON.parse(JSON.stringify(ingressTemplate))
-    // localIngress.metadata.name = project.safeName
-    // localIngress.spec.rules[0].host = project.safeName + '.' + this._options.domain
-    // localIngress.spec.rules[0].http.paths[0].backend.service.name = `${prefix}${project.safeName}`
-
-    // if (process.env.FLOWFORGE_CLOUD_PROVIDER === 'aws' || this._app.config.driver.options.cloudProvider === 'aws') {
-    //     localIngress.metadata.annotations = {
-    //         'kubernetes.io/ingress.class': 'alb',
-    //         'alb.ingress.kubernetes.io/scheme': 'internet-facing',
-    //         'alb.ingress.kubernetes.io/target-type': 'ip',
-    //         'alb.ingress.kubernetes.io/group.name': 'flowforge',
-    //         'alb.ingress.kubernetes.io/listen-ports': '[{"HTTPS":443}, {"HTTP":80}]'
-    //     }
-    // }
-
     project.url = projectURL
     await project.save()
 
     return localPod
-
-    // const promises = []
-    // promises.push(this._k8sApi.createNamespacedPod(namespace, localPod).catch(err => {
-    //     console.log(err)
-    //     this._app.log.error(`[k8s] Project ${project.id} - error creating pod: ${err.toString()}`)
-    //     // rethrow the error so the wrapper knows this hasn't worked
-    //     throw err
-    // }))
-    // /* eslint n/handle-callback-err: "off" */
-    // promises.push(this._k8sApi.createNamespacedService(namespace, localService).catch(err => {
-    //     // TODO: This will fail if the service already exists. Which it okay if
-    //     // we're restarting a suspended project. As we don't know if we're restarting
-    //     // or not, we don't know if this is fatal or not.
-
-    //     // Once we can know if this is a restart or create, then we can decide
-    //     // whether to throw this error or not. For now, this will silently
-    //     // let it pass
-    //     //
-    //     // this._app.log.error(`[k8s] Project ${project.id} - error creating service: ${err.toString()}`)
-    //     // throw err
-    // }))
-
-    // promises.push(this._k8sNetApi.createNamespacedIngress(namespace, localIngress).catch(err => {
-    //     // TODO: This will fail if the service already exists. Which it okay if
-    //     // we're restarting a suspended project. As we don't know if we're restarting
-    //     // or not, we don't know if this is fatal or not.
-
-    //     // Once we can know if this is a restart or create, then we can decide
-    //     // whether to throw this error or not. For now, this will silently
-    //     // let it pass
-    //     //
-    //     // this._app.log.error(`[k8s] Project ${project.id} - error creating ingress: ${err.toString()}`)
-    //     // throw err
-    // }))
-
-    // return Promise.all(promises).then(async () => {
-    //     this._app.log.debug(`[k8s] Container ${project.id} started`)
-    //     project.state = 'running'
-    //     await project.save()
-    //     this._projects[project.id].state = 'starting'
-    // })
 }
 
 module.exports = {
@@ -617,9 +480,8 @@ module.exports = {
                             })
                             .catch(err => {
                                 this._app.log.error(`[k8s] failed to upgrade ${project.id} to deployment`)
-                                // console.log(err)
                             })
-                        // it's just been created, not need to check if it still exists
+                        // it's just been created, not need to check if it still exists in the next block
                         return
                     } catch (err) {
                         // bare pod not found can move on
@@ -630,15 +492,13 @@ module.exports = {
 
                     try {
                         this._app.log.info(`[k8s] Testing ${project.id} in ${namespace} deployment exists`)
-                        await this._k8sAppApi.readNamespacedDeploymentStatus(project.safeName, namespace)
+                        await this._k8sAppApi.readNamespacedDeployment(project.safeName, namespace)
                         this._app.log.info(`[k8s] deployment ${project.id} in ${namespace} found`)
                     } catch (err) {
-                        console.log(`failed to read deployment for ${project.safeName}`)
-                        console.log(err)
                         this._app.log.debug(`[k8s] Project ${project.id} - recreating deployment`)
                         const fullProject = await this._app.db.models.Project.byId(project.id)
                         // await createPod(fullProject)
-                        // await createProject(fullProject, options)
+                        await createProject(fullProject, options)
                     }
                 } catch (err) {
                     this._app.log.error(`[k8s] Project ${project.id} - error resuming project: ${err.stack}`)
@@ -710,7 +570,7 @@ module.exports = {
             const pollInterval = setInterval(async () => {
                 try {
                     // await this._k8sApi.readNamespacedPodStatus(project.safeName, this._namespace)
-                    await this._k8sAppApi.readNamespacedDeploymentStatus(project.safeName, this._namespace)
+                    await this._k8sAppApi.readNamespacedDeployment(project.safeName, this._namespace)
                 } catch (err) {
                     clearInterval(pollInterval)
                     resolve()
@@ -779,9 +639,7 @@ module.exports = {
         try {
             // podDetails = await this._k8sApi.readNamespacedPodStatus(project.safeName, this._namespace)
             podDetails = await this._k8sAppApi.readNamespacedDeployment(project.safeName, this._namespace)
-            // console.log(project.name, podDetails.body)
             if (podDetails.body.status?.conditions[0].status === 'False') {
-            // if (podDetails.body.status?.phase === 'Pending') {
                 // return "starting" status until pod it running
                 this._projects[project.id].state = 'starting'
                 return {
@@ -790,7 +648,6 @@ module.exports = {
                     meta: {}
                 }
             } else if (podDetails.body.status?.conditions[0].status === 'True' && podDetails.body.status?.conditions[0].type === 'Available') {
-            // } else if (podDetails.body.status?.phase === 'Running') {
                 const infoURL = `http://${prefix}${project.safeName}.${this._namespace}:2880/flowforge/info`
                 try {
                     const info = JSON.parse((await got.get(infoURL)).body)
@@ -813,7 +670,6 @@ module.exports = {
                 }
             }
         } catch (err) {
-            // console.log(err)
             this._app.log.debug(`error getting pod status for project ${project.id}: ${err}`)
             return {
                 id: project?.id,

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -495,6 +495,13 @@ module.exports = {
                         await this._k8sAppApi.readNamespacedDeployment(project.safeName, namespace)
                         this._app.log.info(`[k8s] deployment ${project.id} in ${namespace} found`)
                     } catch (err) {
+                        try {
+                            // pod already running
+                            await this._k8sApi.readNamespacedPodStatus(project.safeName, namespace)
+                            return
+                        } catch (err) {
+
+                        }
                         this._app.log.debug(`[k8s] Project ${project.id} - recreating deployment`)
                         const fullProject = await this._app.db.models.Project.byId(project.id)
                         // await createPod(fullProject)

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -395,9 +395,7 @@ const createProject = async (project, options) => {
         // whether to throw this error or not. For now, this will silently
         // let it pass
         //
-        this._app.log.error(`[k8s] Project ${project.id} - error creating ingress: ${err.toString()}`)
-        console.log(err)
-        console.log(localIngress)
+        // this._app.log.error(`[k8s] Project ${project.id} - error creating ingress: ${err.toString()}`)
         // throw err
     }))
 
@@ -607,7 +605,7 @@ module.exports = {
                     // need to upgrade bare pods to deployments
 
                     try {
-                        this._app.log.info(`Testing ${project.id} in ${namespace} is bare pod`)
+                        this._app.log.info(`[k8s] Testing ${project.id} in ${namespace} is bare pod`)
                         await this._k8sApi.readNamespacedPodStatus(project.safeName, namespace)
                         // should only get here is a bare pod exists
                         this._app.log.info(`[k8s] upgrading ${project.id} to deployment`)
@@ -619,16 +617,20 @@ module.exports = {
                             })
                             .catch(err => {
                                 this._app.log.error(`[k8s] failed to upgrade ${project.id} to deployment`)
-                                console.log(err)
+                                // console.log(err)
                             })
                     } catch (err) {
                         // bare pod not found can move on
                     }
 
+                    // look for missing projects
+
                     try {
+                        this._app.log.info(`[k8s] Testing ${project.id} in ${namespace} deployment exists`)
                         await this._k8sAppApi.readNamespacedDeploymentStatus(project.safeName, namespace)
                         this._app.log.info(`[k8s] deployment ${project.id} found`)
                     } catch (err) {
+                        console.log(err)
                         this._app.log.debug(`[k8s] Project ${project.id} - recreating deployment`)
                         const fullProject = await this._app.db.models.Project.byId(project.id)
                         // await createPod(fullProject)

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -22,7 +22,6 @@ const podTemplate = {
             // name: "k8s-client-test",
             nodered: 'true'
             // app: "k8s-client-test",
-            // "pts-node-red": "bronze"
         }
     },
     spec: {
@@ -67,52 +66,57 @@ const podTemplate = {
     enableServiceLinks: false
 }
 
-// const deploymentTemplate = {
-//     apiVersion: 'apps/v1',
-//     kind: 'Deployment',
-//     metadata: {
-//     // name: "k8s-client-test-deployment",
-//         labels: {
-//             // name: "k8s-client-test-deployment",
-//             nodered: 'true'
-//             // app: "k8s-client-test-deployment"
-//         }
-//     },
-//     spec: {
-//         replicas: 1,
-//         selector: {
-//             matchLabels: {
-//                 // app: "k8s-client-test-deployment"
-//             }
-//         },
-//         template: {
-//             metadata: {
-//                 labels: {
-//                     // name: "k8s-client-test-deployment",
-//                     nodered: 'true'
-//                     // app: "k8s-client-test-deployment"
-//                 }
-//             },
-//             spec: {
-//                 containers: [
-//                     {
-//                         name: 'node-red',
-//                         // image: "docker-pi.local:5000/bronze-node-red",
-//                         env: [
-//                             // {name: "APP_NAME", value: "test"},
-//                             { name: 'TZ', value: 'Europe/London' }
-//                         ],
-//                         ports: [
-//                             { name: 'web', containerPort: 1880, protocol: 'TCP' },
-//                             { name: 'management', containerPort: 2880, protocol: 'TCP' }
-//                         ]
-//                     }
-//                 ]
-//             },
-//             enableServiceLinks: false
-//         }
-//     }
-// }
+const deploymentTemplate = {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+    // name: "k8s-client-test-deployment",
+        labels: {
+            // name: "k8s-client-test-deployment",
+            nodered: 'true'
+            // app: "k8s-client-test-deployment"
+        }
+    },
+    spec: {
+        replicas: 1,
+        selector: {
+            matchLabels: {
+                // app: "k8s-client-test-deployment"
+            }
+        },
+        template: {
+            metadata: {
+                labels: {
+                    // name: "k8s-client-test-deployment",
+                    nodered: 'true'
+                    // app: "k8s-client-test-deployment"
+                }
+            },
+            spec: {
+                securityContext: {
+                    runAsUser: 1000,
+                    runAsGroup: 1000,
+                    fsGroup: 1000
+                },
+                containers: [
+                    {
+                        name: 'node-red',
+                        // image: "docker-pi.local:5000/bronze-node-red",
+                        env: [
+                            // {name: "APP_NAME", value: "test"},
+                            { name: 'TZ', value: 'Europe/London' }
+                        ],
+                        ports: [
+                            { name: 'web', containerPort: 1880, protocol: 'TCP' },
+                            { name: 'management', containerPort: 2880, protocol: 'TCP' }
+                        ]
+                    }
+                ]
+            },
+            enableServiceLinks: false
+        }
+    }
+}
 
 const serviceTemplate = {
     apiVersion: 'v1',
@@ -163,9 +167,233 @@ const ingressTemplate = {
     }
 }
 
+const createDeployment = async (project, options) => {
+    const stack = project.ProjectStack.properties
+
+    const localDeployment = JSON.parse(JSON.stringify(deploymentTemplate))
+    const localPod = localDeployment.spec.template
+    localDeployment.metadata.name = project.safeName
+    localDeployment.metadata.labels.name = project.safeName
+    localDeployment.metadata.labels.app = project.id
+    localDeployment.spec.selector.matchLabels.app = project.id
+    localPod.metadata.labels.app = project.id
+
+    if (stack.container) {
+        localPod.spec.containers[0].image = stack.container
+    } else {
+        localPod.spec.containers[0].image = `${this._options.registry}flowforge/node-red`
+    }
+
+    const baseURL = new URL(this._app.config.base_url)
+    const projectURL = `${baseURL.protocol}//${project.safeName}.${this._options.domain}`
+    const teamID = this._app.db.models.Team.encodeHashid(project.TeamId)
+    const authTokens = await project.refreshAuthTokens()
+    localPod.spec.containers[0].env.push({ name: 'FORGE_CLIENT_ID', value: authTokens.clientID })
+    localPod.spec.containers[0].env.push({ name: 'FORGE_CLIENT_SECRET', value: authTokens.clientSecret })
+    localPod.spec.containers[0].env.push({ name: 'FORGE_URL', value: this._app.config.api_url })
+    localPod.spec.containers[0].env.push({ name: 'BASE_URL', value: projectURL })
+    localPod.spec.containers[0].env.push({ name: 'FORGE_TEAM_ID', value: teamID })
+    localPod.spec.containers[0].env.push({ name: 'FORGE_PROJECT_ID', value: project.id })
+    localPod.spec.containers[0].env.push({ name: 'FORGE_PROJECT_TOKEN', value: authTokens.token })
+    // Inbound connections for k8s disabled by default
+    localPod.spec.containers[0].env.push({ name: 'FORGE_NR_NO_TCP_IN', value: 'true' }) // MVP. Future iteration could present this to YML or UI
+    localPod.spec.containers[0].env.push({ name: 'FORGE_NR_NO_UDP_IN', value: 'true' }) // MVP. Future iteration could present this to YML or UI
+    if (authTokens.broker) {
+        localPod.spec.containers[0].env.push({ name: 'FORGE_BROKER_URL', value: authTokens.broker.url })
+        localPod.spec.containers[0].env.push({ name: 'FORGE_BROKER_USERNAME', value: authTokens.broker.username })
+        localPod.spec.containers[0].env.push({ name: 'FORGE_BROKER_PASSWORD', value: authTokens.broker.password })
+    }
+    if (this._app.license.active()) {
+        localPod.spec.containers[0].env.push({ name: 'FORGE_LICENSE_TYPE', value: 'ee' })
+    }
+
+    const credentialSecret = await project.getSetting('credentialSecret')
+    if (credentialSecret) {
+        localPod.spec.containers[0].env.push({ name: 'FORGE_NR_SECRET', value: credentialSecret })
+    }
+
+    if (this._app.config.driver.options.projectSelector) {
+        localPod.spec.nodeSelector = this._app.config.driver.options.projectSelector
+    }
+    if (this._app.config.driver.options.registrySecrets) {
+        localPod.spec.imagePullSecrets = []
+        this._app.config.driver.options.registrySecrets.forEach(sec => {
+            const entry = {
+                name: sec
+            }
+            localPod.spec.imagePullSecrets.push(entry)
+        })
+    }
+
+    if (stack.memory && stack.cpu) {
+        localPod.spec.containers[0].resources.request.memory = `${stack.memory}Mi`
+        localPod.spec.containers[0].resources.limits.memory = `${stack.memory}Mi`
+        localPod.spec.containers[0].resources.request.cpu = `${stack.cpu * 10}m`
+        localPod.spec.containers[0].resources.limits.cpu = `${stack.cpu * 10}m`
+    }
+
+    // const prefix = project.safeName.match(/^[0-9]/) ? 'srv-' : ''
+
+    // const localService = JSON.parse(JSON.stringify(serviceTemplate))
+    // localService.metadata.name = `${prefix}${project.safeName}`
+    // localService.spec.selector.name = project.safeName
+
+    // const localIngress = JSON.parse(JSON.stringify(ingressTemplate))
+    // localIngress.metadata.name = project.safeName
+    // localIngress.spec.rules[0].host = project.safeName + '.' + this._options.domain
+    // localIngress.spec.rules[0].http.paths[0].backend.service.name = `${prefix}${project.safeName}`
+
+    // if (process.env.FLOWFORGE_CLOUD_PROVIDER === 'aws' || this._app.config.driver.options.cloudProvider === 'aws') {
+    //     localIngress.metadata.annotations = {
+    //         'kubernetes.io/ingress.class': 'alb',
+    //         'alb.ingress.kubernetes.io/scheme': 'internet-facing',
+    //         'alb.ingress.kubernetes.io/target-type': 'ip',
+    //         'alb.ingress.kubernetes.io/group.name': 'flowforge',
+    //         'alb.ingress.kubernetes.io/listen-ports': '[{"HTTPS":443}, {"HTTP":80}]'
+    //     }
+    // }
+
+    project.url = projectURL
+    await project.save()
+
+    return localDeployment
+
+    // const promises = []
+    // promises.push(this._k8sAppApi.createNamespacedDeployment(namespace, localDeployment).catch(err => {
+    //     console.log(err)
+    //     this._app.log.error(`[k8s] Project ${project.id} - error creating deployment: ${err.toString()}`)
+    //     // rethrow the error so the wrapper knows this hasn't worked
+    //     throw err
+    // }))
+    // // promises.push(this._k8sApi.createNamespacedPod(namespace, localPod).catch(err => {
+    // //     console.log(err)
+    // //     this._app.log.error(`[k8s] Project ${project.id} - error creating pod: ${err.toString()}`)
+    // //     // rethrow the error so the wrapper knows this hasn't worked
+    // //     throw err
+    // // }))
+    // /* eslint n/handle-callback-err: "off" */
+    // promises.push(this._k8sApi.createNamespacedService(namespace, localService).catch(err => {
+    //     // TODO: This will fail if the service already exists. Which it okay if
+    //     // we're restarting a suspended project. As we don't know if we're restarting
+    //     // or not, we don't know if this is fatal or not.
+
+    //     // Once we can know if this is a restart or create, then we can decide
+    //     // whether to throw this error or not. For now, this will silently
+    //     // let it pass
+    //     //
+    //     // this._app.log.error(`[k8s] Project ${project.id} - error creating service: ${err.toString()}`)
+    //     // throw err
+    // }))
+
+    // promises.push(this._k8sNetApi.createNamespacedIngress(namespace, localIngress).catch(err => {
+    //     // TODO: This will fail if the service already exists. Which it okay if
+    //     // we're restarting a suspended project. As we don't know if we're restarting
+    //     // or not, we don't know if this is fatal or not.
+
+    //     // Once we can know if this is a restart or create, then we can decide
+    //     // whether to throw this error or not. For now, this will silently
+    //     // let it pass
+    //     //
+    //     // this._app.log.error(`[k8s] Project ${project.id} - error creating ingress: ${err.toString()}`)
+    //     // throw err
+    // }))
+
+    // return Promise.all(promises).then(async () => {
+    //     this._app.log.debug(`[k8s] Container ${project.id} started`)
+    //     project.state = 'running'
+    //     await project.save()
+    //     this._projects[project.id].state = 'starting'
+    // })
+}
+
+const createService = async (project, options) => {
+    const prefix = project.safeName.match(/^[0-9]/) ? 'srv-' : ''
+
+    const localService = JSON.parse(JSON.stringify(serviceTemplate))
+    localService.metadata.name = `${prefix}${project.safeName}`
+    localService.spec.selector.name = project.safeName
+    return localService
+}
+
+const createIngress = async (project, options) => {
+    const prefix = project.safeName.match(/^[0-9]/) ? 'srv-' : ''
+
+    const localIngress = JSON.parse(JSON.stringify(ingressTemplate))
+    localIngress.metadata.name = project.safeName
+    localIngress.spec.rules[0].host = project.safeName + '.' + this._options.domain
+    localIngress.spec.rules[0].http.paths[0].backend.service.name = `${prefix}${project.safeName}`
+
+    if (process.env.FLOWFORGE_CLOUD_PROVIDER === 'aws' || this._app.config.driver.options.cloudProvider === 'aws') {
+        localIngress.metadata.annotations = {
+            'kubernetes.io/ingress.class': 'alb',
+            'alb.ingress.kubernetes.io/scheme': 'internet-facing',
+            'alb.ingress.kubernetes.io/target-type': 'ip',
+            'alb.ingress.kubernetes.io/group.name': 'flowforge',
+            'alb.ingress.kubernetes.io/listen-ports': '[{"HTTPS":443}, {"HTTP":80}]'
+        }
+    }
+
+    return localIngress
+}
+
+const createProject = async (project, options) => {
+    const namespace = this._app.config.driver.options.projectNamespace || 'flowforge'
+
+    const localDeployment = await createDeployment(project, options)
+    const localService = await createService(project, options)
+    const localIngress = await createIngress(project, options)
+
+    const promises = []
+    promises.push(this._k8sAppApi.createNamespacedDeployment(namespace, localDeployment).catch(err => {
+        console.log(err)
+        this._app.log.error(`[k8s] Project ${project.id} - error creating deployment: ${err.toString()}`)
+        // rethrow the error so the wrapper knows this hasn't worked
+        throw err
+    }))
+    // promises.push(this._k8sApi.createNamespacedPod(namespace, localPod).catch(err => {
+    //     console.log(err)
+    //     this._app.log.error(`[k8s] Project ${project.id} - error creating pod: ${err.toString()}`)
+    //     // rethrow the error so the wrapper knows this hasn't worked
+    //     throw err
+    // }))
+    /* eslint n/handle-callback-err: "off" */
+    promises.push(this._k8sApi.createNamespacedService(namespace, localService).catch(err => {
+        // TODO: This will fail if the service already exists. Which it okay if
+        // we're restarting a suspended project. As we don't know if we're restarting
+        // or not, we don't know if this is fatal or not.
+
+        // Once we can know if this is a restart or create, then we can decide
+        // whether to throw this error or not. For now, this will silently
+        // let it pass
+        //
+        // this._app.log.error(`[k8s] Project ${project.id} - error creating service: ${err.toString()}`)
+        // throw err
+    }))
+
+    promises.push(this._k8sNetApi.createNamespacedIngress(namespace, localIngress).catch(err => {
+        // TODO: This will fail if the service already exists. Which it okay if
+        // we're restarting a suspended project. As we don't know if we're restarting
+        // or not, we don't know if this is fatal or not.
+
+        // Once we can know if this is a restart or create, then we can decide
+        // whether to throw this error or not. For now, this will silently
+        // let it pass
+        //
+        // this._app.log.error(`[k8s] Project ${project.id} - error creating ingress: ${err.toString()}`)
+        // throw err
+    }))
+
+    return Promise.all(promises).then(async () => {
+        this._app.log.debug(`[k8s] Container ${project.id} started`)
+        project.state = 'running'
+        await project.save()
+        this._projects[project.id].state = 'starting'
+    })
+}
+
 const createPod = async (project, options) => {
     console.log('creating ', project.name, options)
-    const namespace = this._app.config.driver.options.projectNamespace || 'flowforge'
+    // const namespace = this._app.config.driver.options.projectNamespace || 'flowforge'
     const stack = project.ProjectStack.properties
 
     const localPod = JSON.parse(JSON.stringify(podTemplate))
@@ -226,70 +454,72 @@ const createPod = async (project, options) => {
         localPod.spec.containers[0].resources.limits.cpu = `${stack.cpu * 10}m`
     }
 
-    const prefix = project.safeName.match(/^[0-9]/) ? 'srv-' : ''
+    // const prefix = project.safeName.match(/^[0-9]/) ? 'srv-' : ''
 
-    const localService = JSON.parse(JSON.stringify(serviceTemplate))
-    localService.metadata.name = `${prefix}${project.safeName}`
-    localService.spec.selector.name = project.safeName
+    // const localService = JSON.parse(JSON.stringify(serviceTemplate))
+    // localService.metadata.name = `${prefix}${project.safeName}`
+    // localService.spec.selector.name = project.safeName
 
-    const localIngress = JSON.parse(JSON.stringify(ingressTemplate))
-    localIngress.metadata.name = project.safeName
-    localIngress.spec.rules[0].host = project.safeName + '.' + this._options.domain
-    localIngress.spec.rules[0].http.paths[0].backend.service.name = `${prefix}${project.safeName}`
+    // const localIngress = JSON.parse(JSON.stringify(ingressTemplate))
+    // localIngress.metadata.name = project.safeName
+    // localIngress.spec.rules[0].host = project.safeName + '.' + this._options.domain
+    // localIngress.spec.rules[0].http.paths[0].backend.service.name = `${prefix}${project.safeName}`
 
-    if (process.env.FLOWFORGE_CLOUD_PROVIDER === 'aws' || this._app.config.driver.options.cloudProvider === 'aws') {
-        localIngress.metadata.annotations = {
-            'kubernetes.io/ingress.class': 'alb',
-            'alb.ingress.kubernetes.io/scheme': 'internet-facing',
-            'alb.ingress.kubernetes.io/target-type': 'ip',
-            'alb.ingress.kubernetes.io/group.name': 'flowforge',
-            'alb.ingress.kubernetes.io/listen-ports': '[{"HTTPS":443}, {"HTTP":80}]'
-        }
-    }
+    // if (process.env.FLOWFORGE_CLOUD_PROVIDER === 'aws' || this._app.config.driver.options.cloudProvider === 'aws') {
+    //     localIngress.metadata.annotations = {
+    //         'kubernetes.io/ingress.class': 'alb',
+    //         'alb.ingress.kubernetes.io/scheme': 'internet-facing',
+    //         'alb.ingress.kubernetes.io/target-type': 'ip',
+    //         'alb.ingress.kubernetes.io/group.name': 'flowforge',
+    //         'alb.ingress.kubernetes.io/listen-ports': '[{"HTTPS":443}, {"HTTP":80}]'
+    //     }
+    // }
 
     project.url = projectURL
     await project.save()
 
-    const promises = []
-    promises.push(this._k8sApi.createNamespacedPod(namespace, localPod).catch(err => {
-        console.log(err)
-        this._app.log.error(`[k8s] Project ${project.id} - error creating pod: ${err.toString()}`)
-        // rethrow the error so the wrapper knows this hasn't worked
-        throw err
-    }))
-    /* eslint n/handle-callback-err: "off" */
-    promises.push(this._k8sApi.createNamespacedService(namespace, localService).catch(err => {
-        // TODO: This will fail if the service already exists. Which it okay if
-        // we're restarting a suspended project. As we don't know if we're restarting
-        // or not, we don't know if this is fatal or not.
+    return localPod
 
-        // Once we can know if this is a restart or create, then we can decide
-        // whether to throw this error or not. For now, this will silently
-        // let it pass
-        //
-        // this._app.log.error(`[k8s] Project ${project.id} - error creating service: ${err.toString()}`)
-        // throw err
-    }))
+    // const promises = []
+    // promises.push(this._k8sApi.createNamespacedPod(namespace, localPod).catch(err => {
+    //     console.log(err)
+    //     this._app.log.error(`[k8s] Project ${project.id} - error creating pod: ${err.toString()}`)
+    //     // rethrow the error so the wrapper knows this hasn't worked
+    //     throw err
+    // }))
+    // /* eslint n/handle-callback-err: "off" */
+    // promises.push(this._k8sApi.createNamespacedService(namespace, localService).catch(err => {
+    //     // TODO: This will fail if the service already exists. Which it okay if
+    //     // we're restarting a suspended project. As we don't know if we're restarting
+    //     // or not, we don't know if this is fatal or not.
 
-    promises.push(this._k8sNetApi.createNamespacedIngress(namespace, localIngress).catch(err => {
-        // TODO: This will fail if the service already exists. Which it okay if
-        // we're restarting a suspended project. As we don't know if we're restarting
-        // or not, we don't know if this is fatal or not.
+    //     // Once we can know if this is a restart or create, then we can decide
+    //     // whether to throw this error or not. For now, this will silently
+    //     // let it pass
+    //     //
+    //     // this._app.log.error(`[k8s] Project ${project.id} - error creating service: ${err.toString()}`)
+    //     // throw err
+    // }))
 
-        // Once we can know if this is a restart or create, then we can decide
-        // whether to throw this error or not. For now, this will silently
-        // let it pass
-        //
-        // this._app.log.error(`[k8s] Project ${project.id} - error creating ingress: ${err.toString()}`)
-        // throw err
-    }))
+    // promises.push(this._k8sNetApi.createNamespacedIngress(namespace, localIngress).catch(err => {
+    //     // TODO: This will fail if the service already exists. Which it okay if
+    //     // we're restarting a suspended project. As we don't know if we're restarting
+    //     // or not, we don't know if this is fatal or not.
 
-    return Promise.all(promises).then(async () => {
-        this._app.log.debug(`[k8s] Container ${project.id} started`)
-        project.state = 'running'
-        await project.save()
-        this._projects[project.id].state = 'starting'
-    })
+    //     // Once we can know if this is a restart or create, then we can decide
+    //     // whether to throw this error or not. For now, this will silently
+    //     // let it pass
+    //     //
+    //     // this._app.log.error(`[k8s] Project ${project.id} - error creating ingress: ${err.toString()}`)
+    //     // throw err
+    // }))
+
+    // return Promise.all(promises).then(async () => {
+    //     this._app.log.debug(`[k8s] Container ${project.id} started`)
+    //     project.state = 'running'
+    //     await project.save()
+    //     this._projects[project.id].state = 'starting'
+    // })
 }
 
 module.exports = {
@@ -348,18 +578,41 @@ module.exports = {
 
         this._initialCheckTimeout = setTimeout(() => {
             this._app.log.debug('[k8s] Restarting projects')
+            const namespace = options.projectNamespace || 'flowforge'
             projects.forEach(async (project) => {
                 try {
                     if (project.state === 'suspended') {
                         // Do not restart suspended projects
                         return
                     }
+
+                    // need to upgrade bare pods to deployments
+
                     try {
-                        await this._k8sApi.readNamespacedPodStatus(project.safeName, this._namespace)
+                        this._app.log.info(`Testing ${project.safeName} in ${namespace} is bare pod`)
+                        await this._k8sApi.readNamespacedPodStatus(project.safeName, namespace)
+                        // should only get here is a bare pod exists
+                        this._app.log.info(`[k8s] upgrading ${project.id} to deployment`)
+                        const fullProject = await this._app.db.models.Project.byId(project.id)
+                        const localDeployment = createDeployment(fullProject, options)
+                        this._k8sAppApi.createNamespacedDeployment(localDeployment, namespace)
+                            .then(() => {
+                                return this._k8sApi.deleteNamespacedPod(project.safeName, namespace)
+                            })
+                            .catch(err => {
+                                this._app.log.error(`[k8s] failed to upgrade ${project.id} to deployment`)
+                            })
+                    } catch (err) {
+                        // bare pod not found can move on
+                    }
+
+                    try {
+                        await this._k8sAppApi.readNamespacedDeploymentStatus(project.safeName, this._namespace)
                     } catch (err) {
                         this._app.log.debug(`[k8s] Project ${project.id} - recreating container`)
                         const fullProject = await this._app.db.models.Project.byId(project.id)
-                        await createPod(fullProject)
+                        // await createPod(fullProject)
+                        await createProject(fullProject, options)
                     }
                 } catch (err) {
                     this._app.log.error(`[k8s] Project ${project.id} - error resuming project: ${err.stack}`)
@@ -412,7 +665,8 @@ module.exports = {
 
         // Remember, this call is used for both creating a new project as well as
         // restarting an existing project
-        return createPod(project)
+        // return createPod(project)
+        return createProject(project, this._options)
     },
 
     /**
@@ -462,7 +716,8 @@ module.exports = {
         try {
             // A suspended project won't have a pod to delete - but try anyway
             // just in case state has got out of sync
-            await this._k8sApi.deleteNamespacedPod(project.safeName, this._namespace)
+            // await this._k8sApi.deleteNamespacedPod(project.safeName, this._namespace)
+            await this._k8sAppApi.deleteNamespacedDeployment(project.safeName, this._namespace)
         } catch (err) {
             if (project.state !== 'suspended') {
                 // A suspended project is expected to error here - so only log

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -336,7 +336,7 @@ const createIngress = async (project, options) => {
 
     const localIngress = JSON.parse(JSON.stringify(ingressTemplate))
     localIngress.metadata.name = project.safeName
-    localIngress.spec.rules[0].host = project.safeName + '.' + this._options.domain
+    localIngress.spec.rules[0].host = project.safeName + '.' + options.domain
     localIngress.spec.rules[0].http.paths[0].backend.service.name = `${prefix}${project.safeName}`
 
     if (process.env.FLOWFORGE_CLOUD_PROVIDER === 'aws' || this._app.config.driver.options.cloudProvider === 'aws') {
@@ -396,6 +396,8 @@ const createProject = async (project, options) => {
         // let it pass
         //
         this._app.log.error(`[k8s] Project ${project.id} - error creating ingress: ${err.toString()}`)
+        console.log(err)
+        console.log(localIngress)
         // throw err
     }))
 

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -634,7 +634,7 @@ module.exports = {
         const prefix = project.safeName.match(/^[0-9]/) ? 'srv-' : ''
         // this._app.log.debug('checking actual pod, not cache')
 
-        /** @type { { response: IncomingMessage, body: k8s.V1Pod } } */
+        /** @type { { response: IncomingMessage, body: k8s.V1Deployment } } */
         let podDetails
         try {
             // podDetails = await this._k8sApi.readNamespacedPodStatus(project.safeName, this._namespace)

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -395,7 +395,7 @@ const createProject = async (project, options) => {
         // whether to throw this error or not. For now, this will silently
         // let it pass
         //
-        // this._app.log.error(`[k8s] Project ${project.id} - error creating ingress: ${err.toString()}`)
+        this._app.log.error(`[k8s] Project ${project.id} - error creating ingress: ${err.toString()}`)
         // throw err
     }))
 
@@ -771,7 +771,7 @@ module.exports = {
         try {
             // podDetails = await this._k8sApi.readNamespacedPodStatus(project.safeName, this._namespace)
             podDetails = await this._k8sAppApi.readNamespacedDeployment(project.safeName, this._namespace)
-            console.log(project.name, podDetails.body)
+            // console.log(project.name, podDetails.body)
             if (podDetails.body.status?.conditions[0].status === 'False') {
             // if (podDetails.body.status?.phase === 'Pending') {
                 // return "starting" status until pod it running

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -100,6 +100,17 @@ const deploymentTemplate = {
                 },
                 containers: [
                     {
+                        resources: {
+                            request: {
+                                // 10th of a core
+                                cpu: '100m',
+                                memory: '128Mi'
+                            },
+                            limits: {
+                                cpu: '125m',
+                                memory: '192Mi'
+                            }
+                        },
                         name: 'node-red',
                         // image: "docker-pi.local:5000/bronze-node-red",
                         env: [

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -771,8 +771,9 @@ module.exports = {
         try {
             // podDetails = await this._k8sApi.readNamespacedPodStatus(project.safeName, this._namespace)
             podDetails = await this._k8sAppApi.readNamespacedDeployment(project.safeName, this._namespace)
-            // console.log(project.name, podDetails.body)
-            if (podDetails.body.status?.phase === 'Pending') {
+            console.log(project.name, podDetails.body)
+            if (podDetails.body.status?.conditions[0].status === 'False') {
+            // if (podDetails.body.status?.phase === 'Pending') {
                 // return "starting" status until pod it running
                 this._projects[project.id].state = 'starting'
                 return {
@@ -780,7 +781,8 @@ module.exports = {
                     state: 'starting',
                     meta: {}
                 }
-            } else if (podDetails.body.status?.phase === 'Running') {
+            } else if (podDetails.body.status?.conditions[0].status === 'True' && podDetails.body.status?.conditions[0].type === 'Available') {
+            // } else if (podDetails.body.status?.phase === 'Running') {
                 const infoURL = `http://${prefix}${project.safeName}.${this._namespace}:2880/flowforge/info`
                 try {
                     const info = JSON.parse((await got.get(infoURL)).body)


### PR DESCRIPTION
## Description

Alternative to #68 

The K8s Driver currently creates bare Pods which are not automatically migrated to new a Node when the current Node is shutdown, this prevents migration as part of upgrades and in case of AWS/Hardware failures.

This PR only upgrades from bare Pod to Deployment if the project is suspended and restarted.

New projects are created as Deployment

If the driver finds a missing project at startup it will recreate it as a Deployment.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

