### PR TITLE
Add Support for Private Certificate Authorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ driver:
       role: projects
     projectNamespace: flowforge
     cloudProvider: aws
+    privateCA: ff-ca-certs
 ```
 
 - `registry` is the Docker Registry to load Stack Containers from
@@ -24,5 +25,6 @@ driver:
 should run on
 - `cloudProvider` can be left unset for none `aws` deployments. This triggers the adding of
 AWS EKS specific annotation for ALB Ingress.
+- `privateCA` name of ConfigMap holding PEM CA Cert Bundle (file name `certs.pem`) Optional
 
 Expects to pick up K8s credentials from the environment

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -241,6 +241,25 @@ const createDeployment = async (project, options) => {
         })
     }
 
+    if (this._app.config.driver.options.privateCA) {
+        localPod.spec.container[0].volumeMounts = [
+            {
+                name: 'caCert',
+                mountPath: '/usr/local/ssl-certs',
+                readOnly: true
+            }
+        ]
+        localPod.spec.volumes = [
+            {
+                name: 'caCert',
+                configMap: {
+                    name: this._app.config.driver.privateCA
+                }
+            }
+        ]
+        localPod.spec.containers[0].env.push({ name: 'NODE_EXTRA_CA_CERTS', value: '/usr/local/ssl-certs/chain.pem' })
+    }
+
     if (stack.memory && stack.cpu) {
         localPod.spec.containers[0].resources.request.memory = `${stack.memory}Mi`
         localPod.spec.containers[0].resources.limits.memory = `${stack.memory}Mi`

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -242,16 +242,16 @@ const createDeployment = async (project, options) => {
     }
 
     if (this._app.config.driver.options.privateCA) {
-        localPod.spec.container[0].volumeMounts = [
+        localPod.spec.containers[0].volumeMounts = [
             {
-                name: 'caCert',
+                name: 'cacert',
                 mountPath: '/usr/local/ssl-certs',
                 readOnly: true
             }
         ]
         localPod.spec.volumes = [
             {
-                name: 'caCert',
+                name: 'cacert',
                 configMap: {
                     name: this._app.config.driver.privateCA
                 }

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -253,7 +253,7 @@ const createDeployment = async (project, options) => {
             {
                 name: 'cacert',
                 configMap: {
-                    name: this._app.config.driver.privateCA
+                    name: this._app.config.driver.options.privateCA
                 }
             }
         ]

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -303,6 +303,8 @@ const createProject = async (project, options) => {
     const promises = []
     promises.push(this._k8sAppApi.createNamespacedDeployment(namespace, localDeployment).catch(err => {
         this._app.log.error(`[k8s] Project ${project.id} - error creating deployment: ${err.toString()}`)
+        this._app.log.error(`[k8s] deployment ${JSON.stringify(localDeployment, undefined, 2)}`)
+        this._app.log.error(err)
         // rethrow the error so the wrapper knows this hasn't worked
         throw err
     }))


### PR DESCRIPTION
## Description

Allow a bundle of CA Certs to be provided to the Node-RED process to authenticate TLS certificates

## Related Issue(s)

https://github.com/flowforge/flowforge/issues/1525

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

