### PR TITLE
Editor configuration from process environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ AWS EKS specific annotation for ALB Ingress.
 - `privateCA` name of ConfigMap holding PEM CA Cert Bundle (file name `certs.pem`) Optional
 
 Expects to pick up K8s credentials from the environment
+
+### Configuration via environment variables
+
+Next variables are read from flowforge process environment in runtime:
+
+* `INGRESS_CLASS_NAME` - `Ingress` class name for editor instances
+* `INGRESS_ANNOTATIONS` - `Ingress` annotations for editor instances as JSON-encoded object
+* `DEPLOYMENT_TOLERATIONS` - Editor `Deployment` tolerations as JSON-encoded object

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -157,11 +157,10 @@ const ingressTemplate = {
     metadata: {
         // name: "k8s-client-test-ingress",
         // namespace: 'flowforge',
-        // annotations: {}
-        annotations: JSON.parse(process.env.INGRESS_ANNOTATIONS)
+        annotations: process.env.INGRESS_ANNOTATIONS ? JSON.parse(process.env.INGRESS_ANNOTATIONS) : {}
     },
     spec: {
-        ingressClassName: process.env.INGRESS_CLASS_NAME,
+        ingressClassName: process.env.INGRESS_CLASS_NAME ? process.env.INGRESS_CLASS_NAME : null,
         rules: [
             {
                 // host: "k8s-client-test" + "." + "ubuntu.local",

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -220,7 +220,6 @@ const createDeployment = async (project, options) => {
     // operator: Equal
     // value: skills
     // effect: NoSchedule
-    //if (proc.env.POD_AFFINITY !== undefined && proc.env.POD_TOLERATIONS !== undefined){
     if (process.env.DEPLOYMENT_TOLERATIONS !== undefined){
         // TOLERATIONS
         try {


### PR DESCRIPTION
## Description

When Flowforge works in K8s cluster, it might be necessary to set some K8S cluster specific settings of editor instances created by FF.
Those settings are likely to be generated by deployment scripts and set by DevOpses, not by team administrators on WebUI, therefore we think that is is most convenient to store in in flowforge process environment but not in the database.

This PR adds next settings:

* `INGRESS_CLASS_NAME` - `Ingress` class name for editor instances
* `INGRESS_ANNOTATIONS` - `Ingress` annotations for editor instances as JSON-encoded object
* `DEPLOYMENT_TOLERATIONS` - Editor `Deployment` tolerations as JSON-encoded object

The changes are backward compatible.
PR for FF Helm which allows to set those settings TBD.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

