### PR TITLE
Log failures if not restarting susspended project

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -358,7 +358,9 @@ const createProject = async (project, options) => {
         // whether to throw this error or not. For now, this will silently
         // let it pass
         //
-        // this._app.log.error(`[k8s] Project ${project.id} - error creating service: ${err.toString()}`)
+        if (project.state !== 'suspended') {
+            this._app.log.error(`[k8s] Project ${project.id} - error creating service: ${err.toString()}`)
+        }
         // throw err
     }))
 
@@ -371,7 +373,9 @@ const createProject = async (project, options) => {
         // whether to throw this error or not. For now, this will silently
         // let it pass
         //
-        // this._app.log.error(`[k8s] Project ${project.id} - error creating ingress: ${err.toString()}`)
+        if (project.state !== 'suspended') {
+            this._app.log.error(`[k8s] Project ${project.id} - error creating ingress: ${err.toString()}`)
+        }
         // throw err
     }).then(async () => {
         this._app.log.info(`[k8s] Ingress creation completed for project ${project.id}`)


### PR DESCRIPTION
fixes #75

## Description

<!-- Describe your changes in detail -->
Log failure to create Service and Ingress objects if project is not starting from being suspended.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#75

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

