### PR TITLE
Editors: allow optional service account linkage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ Next variables are read from flowforge process environment in runtime:
 * `INGRESS_CLASS_NAME` - `Ingress` class name for editor instances
 * `INGRESS_ANNOTATIONS` - `Ingress` annotations for editor instances as JSON-encoded object
 * `DEPLOYMENT_TOLERATIONS` - Editor `Deployment` tolerations as JSON-encoded object
+* `EDITOR_SERVICE_ACCOUNT` - Editor service account. 

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -232,6 +232,7 @@ const createDeployment = async (project, options) => {
 
     localPod.metadata.labels.app = project.id
     localPod.metadata.labels.name = project.safeName
+    localPod.spec.serviceAccount = process.env.EDITOR_SERVICE_ACCOUNT
 
     if (stack.container) {
         localPod.spec.containers[0].image = stack.container


### PR DESCRIPTION
Editors: allow optional default service account linkage if specified by FlowForge helm deployment.

## Description

Editors: allow optional service account linkage if this specified by FlowForge helm deployment.
FlowForge helm relevant section is
```yaml
editors:
  serviceAccount:
    create: true
    annotations: {}
    name: editors
```

Relevant environment variable is `EDITOR_SERVICE_ACCOUNT`.
*Note that by "default" here meant that all Editor instances will be provisioned with this service account linked.

> **Motivation**: In general, there's a need and the plan for multiple IAM support, per Project, as a part of Project Configuration with the ability to change IAM binding (likewise the stack can be changed). To start simple, we consider a unified role linkage to unlock the cloud development on Editor instance, with that we link the default service account to Editor instances deployment via env variable. 
> Later this might be the definition "from project settings".

## Related Issue(s)

- [Editors: allow optional service account linkage](https://github.com/flowforge/flowforge-driver-k8s/issues/91)
- [FlowForge helm: 1. Editors: service account. 2. Broker: propagate ingress. 3. README](https://github.com/flowforge/helm/pull/148)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

