### PR TITLE
Added support for annotation substitutions

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -335,19 +335,27 @@ const createService = async (project, options) => {
 const mustache = (string, data = {}) =>
   Object.entries(data).reduce((res, [key, value]) => res.replace(new RegExp(`{{\\s*${key}\\s*}}`, "g"), value), string);
 
-
 const createIngress = async (project, options) => {
     const prefix = project.safeName.match(/^[0-9]/) ? 'srv-' : ''
-
     const url = new URL(project.url)
+    
+    // exposedData available for annotation replacements
+    const exposedData = {
+        serviceName: `${prefix}${project.safeName}`,
+        instanceURL: url.href,
+        instanceHost: url.host,
+        instanceProtocol: url.protocol,
+    }
 
     this._app.log.info('K8S DRIVER: start parse ingress template')
+
     const localIngress = JSON.parse(JSON.stringify(ingressTemplate))
 
-    // process annotations with replacement
+    // process annotations with potential replacements
     Object.keys(localIngress.metadata.annotations).forEach((key)=>{
-        localIngress.metadata.annotations[key] = mustache(localIngress.metadata.annotations[key],{...project, prefix, host:url.host})
+        localIngress.metadata.annotations[key] = mustache(localIngress.metadata.annotations[key],exposedData)
     })
+
     localIngress.metadata.name = project.safeName
     localIngress.spec.rules[0].host = url.host
     localIngress.spec.rules[0].http.paths[0].backend.service.name = `${prefix}${project.safeName}`

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -333,18 +333,18 @@ const createService = async (project, options) => {
 }
 
 const mustache = (string, data = {}) =>
-  Object.entries(data).reduce((res, [key, value]) => res.replace(new RegExp(`{{\\s*${key}\\s*}}`, "g"), value), string);
+    Object.entries(data).reduce((res, [key, value]) => res.replace(new RegExp(`{{\\s*${key}\\s*}}`, 'g'), value), string)
 
 const createIngress = async (project, options) => {
     const prefix = project.safeName.match(/^[0-9]/) ? 'srv-' : ''
     const url = new URL(project.url)
-    
+
     // exposedData available for annotation replacements
     const exposedData = {
         serviceName: `${prefix}${project.safeName}`,
         instanceURL: url.href,
         instanceHost: url.host,
-        instanceProtocol: url.protocol,
+        instanceProtocol: url.protocol
     }
 
     this._app.log.info('K8S DRIVER: start parse ingress template')
@@ -352,8 +352,8 @@ const createIngress = async (project, options) => {
     const localIngress = JSON.parse(JSON.stringify(ingressTemplate))
 
     // process annotations with potential replacements
-    Object.keys(localIngress.metadata.annotations).forEach((key)=>{
-        localIngress.metadata.annotations[key] = mustache(localIngress.metadata.annotations[key],exposedData)
+    Object.keys(localIngress.metadata.annotations).forEach((key) => {
+        localIngress.metadata.annotations[key] = mustache(localIngress.metadata.annotations[key], exposedData)
     })
 
     localIngress.metadata.name = project.safeName

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -349,7 +349,6 @@ const createIngress = async (project, options) => {
         localIngress.metadata.annotations[key] = mustache(localIngress.metadata.annotations[key],project)
     })
     localIngress.metadata.name = project.safeName
-    localIngress.metadata.annotations["nginx.org/websocket-services"] = project.safeName
     localIngress.spec.rules[0].host = url.host
     localIngress.spec.rules[0].http.paths[0].backend.service.name = `${prefix}${project.safeName}`
 

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -340,6 +340,7 @@ const createIngress = async (project, options) => {
     this._app.log.info('K8S DRIVER: start parse ingress template')
     const localIngress = JSON.parse(JSON.stringify(ingressTemplate))
     localIngress.metadata.name = project.safeName
+    localIngress.metadata.annotations["nginx.org/websocket-services"] = project.safeName
     localIngress.spec.rules[0].host = url.host
     localIngress.spec.rules[0].http.paths[0].backend.service.name = `${prefix}${project.safeName}`
 

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -346,7 +346,7 @@ const createIngress = async (project, options) => {
 
     // process annotations with replacement
     Object.keys(localIngress.metadata.annotations).forEach((key)=>{
-        localIngress.metadata.annotations[key] = mustache(localIngress.metadata.annotations[key],project)
+        localIngress.metadata.annotations[key] = mustache(localIngress.metadata.annotations[key],{project, prefix, url})
     })
     localIngress.metadata.name = project.safeName
     localIngress.spec.rules[0].host = url.host

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -332,6 +332,10 @@ const createService = async (project, options) => {
     return localService
 }
 
+const mustache = (string, data = {}) =>
+  Object.entries(data).reduce((res, [key, value]) => res.replace(new RegExp(`{{\\s*${key}\\s*}}`, "g"), value), string);
+
+
 const createIngress = async (project, options) => {
     const prefix = project.safeName.match(/^[0-9]/) ? 'srv-' : ''
 
@@ -339,6 +343,11 @@ const createIngress = async (project, options) => {
 
     this._app.log.info('K8S DRIVER: start parse ingress template')
     const localIngress = JSON.parse(JSON.stringify(ingressTemplate))
+
+    // process annotations with replacement
+    Object.keys(localIngress.metadata.annotations).forEach((key)=>{
+        localIngress.metadata.annotations[key] = mustache(localIngress.metadata.annotations[key],project)
+    })
     localIngress.metadata.name = project.safeName
     localIngress.metadata.annotations["nginx.org/websocket-services"] = project.safeName
     localIngress.spec.rules[0].host = url.host

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -346,7 +346,7 @@ const createIngress = async (project, options) => {
 
     // process annotations with replacement
     Object.keys(localIngress.metadata.annotations).forEach((key)=>{
-        localIngress.metadata.annotations[key] = mustache(localIngress.metadata.annotations[key],{project, prefix, url})
+        localIngress.metadata.annotations[key] = mustache(localIngress.metadata.annotations[key],{...project, prefix, host:url.host})
     })
     localIngress.metadata.name = project.safeName
     localIngress.spec.rules[0].host = url.host


### PR DESCRIPTION
Added websocket annotation for nginx ingress k8s

## Description

added the nginx annotation for websocket support in k8s

## Related Issue(s)

[(https://github.com/flowforge/flowforge-driver-k8s/issues/83)](https://github.com/flowforge/flowforge-driver-k8s/issues/83)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? --> Not needed


## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

