### PR TITLE
Remove evreything on suspend

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -686,9 +686,17 @@ module.exports = {
             this._app.log.error(`[k8s] Project ${project.id} - error deleting ingress: ${err.toString()}`)
         }
         if (project.safeName.match(/^[0-9]/)) {
-            await this._k8sApi.deleteNamespacedService('srv-' + project.safeName, this._namespace)
+            try {
+                await this._k8sApi.deleteNamespacedService('srv-' + project.safeName, this._namespace)
+            } catch (err) {
+                this._app.log.error(`[k8s] Project ${project.id} - error deleting service: ${err.toString()}`)
+            }
         } else {
-            await this._k8sApi.deleteNamespacedService(project.safeName, this._namespace)
+            try {
+                await this._k8sApi.deleteNamespacedService(project.safeName, this._namespace)
+            } catch (err) {
+                this._app.log.error(`[k8s] Project ${project.id} - error deleting service: ${err.toString()}`)
+            }
         }
 
         // For now, we just want to remove the Pod/Deployment


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Suspended instances didn't used to delete ingress and service objects, which could lead to problems with nodeport services.

Since we automatically try and recreate both the service and ingress when restarting a suspended instance, no reason not to remove them.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#97 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

