### PR TITLE
Move to CluserIP

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -140,7 +140,7 @@ const serviceTemplate = {
         // name: "k8s-client-test-service"
     },
     spec: {
-        type: 'NodePort',
+        type: 'ClusterIP',
         selector: {
             // name: "k8s-client-test"
         },


### PR DESCRIPTION
fixes #97 
## Description

<!-- Describe your changes in detail -->
Change the default Service Type to ClusterIP from NodePort to prevent exhausting NodePort range

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#97 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

