### PR TITLE
Ensure the logs are mixed for HA instances

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -1136,9 +1136,12 @@ module.exports = {
                 logRequests.push(got.get(`http://${addresses[address]}:2880/flowforge/logs`).json())
             }
             const results = await Promise.all(logRequests)
-            const combinedResults = results.flat(1)
+            const combinedResults = results[0].logs.concat(results[1].logs)
             combinedResults.sort((a, b) => { return a.ts - b.ts })
-            return combinedResults
+            return {
+                meta: results[0].meta,
+                logs: combinedResults
+            }
         } else {
             const prefix = project.safeName.match(/^[0-9]/) ? 'srv-' : ''
             const result = await got.get(`http://${prefix}${project.safeName}.${this._namespace}:2880/flowforge/logs`).json()


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Ensure that HA logs get combined properly now we have paging enabled.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

