### PR TITLE
feat: Add possibility to configure probes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ driver:
 - `projectSelector` a list of labels that should be used to select which nodes Project Pods
 should run on
 - `projectLabels` a list of custom labels that should be applied to all resources created for Projects (Pods, Services, Ingresses, PVCs)
+- `projectProbes` optional configuration for liveness, readiness and startup probes for project containers
+- `projectProbes.livenessProbe` custom liveness probe configuration (default not set)
+- `projectProbes.readinessProbe` custom readiness probe configuration (default not set)
+- `projectProbes.startupProbe` custom startup probe configuration (default not set)
 - `cloudProvider` normally not set, but can be `aws` This triggers the adding of
 AWS EKS specific annotation for ALB Ingress. or `openshift` to allow running on OpenShift (Enterprise license only)
 - `privateCA` name of ConfigMap holding PEM CA Cert Bundle (file name `certs.pem`) Optional

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -213,6 +213,16 @@ const createDeployment = async (project, options) => {
         }
     }
 
+    if (this._app.config.driver.options?.projectProbes?.livenessProbe) {
+        localPod.spec.containers[0].livenessProbe = this._app.config.driver.options.projectProbes.livenessProbe
+    }
+    if (this._app.config.driver.options?.projectProbes?.readinessProbe) {
+        localPod.spec.containers[0].readinessProbe = this._app.config.driver.options.projectProbes.readinessProbe
+    }
+    if (this._app.config.driver.options?.projectProbes?.startupProbe) {
+        localPod.spec.containers[0].startupProbe = this._app.config.driver.options.projectProbes.startupProbe
+    }
+
     const ha = await project.getSetting('ha')
     if (ha?.replicas > 1) {
         localDeployment.spec.replicas = ha.replicas


### PR DESCRIPTION
## Description

This pull request extends the Kubernetes driver by adding a possibility to define liveness, readiness and startup probes for projects.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/708

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

