### PR TITLE
feat: Add possibility to configure container security context

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ AWS EKS specific annotation for ALB Ingress. or `openshift` to allow running on 
 - `storage.storageClassEFSTag` Used instead of `storage.storageClass` when needing to shard across multiple EFS file systems (default not set)
 - `storage.size` Size of the volume to request (default not set)
 - `podSecurityContext` Settings linked to the [security context of the pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+- `containerSecurityContext` Settings linked to the [security context of the container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
 - `service.type` Type of service to create for the editor (allowed `ClusterIP` or `NodePort`, default `ClusterIP`)
 
 Expects to pick up K8s credentials from the environment

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -194,6 +194,14 @@ const createDeployment = async (project, options) => {
         this._app.log.info('[k8s] OpenShift, removing PodSecurityContext')
     }
 
+    if (this._app.config.driver.options?.containerSecurityContext) {
+        localPod.spec.containers[0].securityContext = this._app.config.driver.options.containerSecurityContext
+        this._app.log.info(`[k8s] Using custom ContainerSecurityContext ${JSON.stringify(this._app.config.driver.options.containerSecurityContext)}`)
+    } else if (this._app.license.active() && this._cloudProvider === 'openshift') {
+        localPod.spec.containers[0].securityContext = {}
+        this._app.log.info('[k8s] OpenShift, removing ContainerSecurityContext')
+    }
+
     if (stack.memory && stack.cpu) {
         localPod.spec.containers[0].resources.requests.memory = `${stack.memory}Mi`
         // increase limit to give npm more room to run in


### PR DESCRIPTION
## Description

This pull request extends the Kubernetes driver by adding a possibility to configure container security context.

## Related Issue(s)

https://github.com/FlowFuse/driver-k8s/issues/249

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

