### PR TITLE
Force Numeric Annotations to be strings

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -320,8 +320,6 @@ const createIngress = async (project, options) => {
         ]
     }
 
-    this._app.log.info(`K8S DRIVER: ingress annotations ${this._projectIngressAnnotations}`)
-
     // process annotations with potential replacements
     Object.keys(localIngress.metadata.annotations).forEach((key) => {
         localIngress.metadata.annotations[key] = mustache(`${localIngress.metadata.annotations[key]}`, exposedData)
@@ -334,8 +332,6 @@ const createIngress = async (project, options) => {
     localIngress.metadata.name = project.safeName
     localIngress.spec.rules[0].host = url.host
     localIngress.spec.rules[0].http.paths[0].backend.service.name = `${prefix}${project.safeName}`
-
-    this._app.log.info(`K8S DRIVER: ingress ${JSON.stringify(localIngress, null, 2)}`)
 
     return localIngress
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
The substition processor failed with annotation values that were being automatically converted from strings to numbers.

