### PR TITLE
feat: Add default startup probe values

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -229,17 +229,6 @@ const createDeployment = async (project, options) => {
     }
     if (this._app.config.driver.options?.projectProbes?.startupProbe) {
         localPod.spec.containers[0].startupProbe = this._app.config.driver.options.projectProbes.startupProbe
-    } else {
-        localPod.spec.containers[0].startupProbe = {
-            httpGet: {
-                path: '/flowforge/ready',
-                port: deploymentTemplate.spec.template.spec.containers[0].ports[1].name
-            },
-            initialDelaySeconds: 5,
-            periodSeconds: 2,
-            successThreshold: 1,
-            failureThreshold: 300
-        }
     }
 
     const ha = await project.getSetting('ha')

--- a/templates.js
+++ b/templates.js
@@ -56,6 +56,16 @@ const deploymentTemplate = {
                         ],
                         securityContext: {
                             allowPrivilegeEscalation: false
+                        },
+                        startupProbe: {
+                            httpGet: {
+                                path: '/flowforge/ready',
+                                port: 'management'
+                            },
+                            initialDelaySeconds: 5,
+                            periodSeconds: 2,
+                            successThreshold: 1,
+                            failureThreshold: 450
                         }
                     }
                 ]


### PR DESCRIPTION
## Description

This pull request adds default `startupProbe` values for the Node-RED container.
By default, startup probe:
* uses `/flowforge/ready` endpoint
* uses management port
* waits 5 seconds after container startup
* checks the endpoint every 2 seconds
* expects 1 successfull response
* accepts 300 consecutive failures before restartong the pod

## Related Issue(s)

Closes https://github.com/FlowFuse/driver-k8s/issues/233

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

