### PR TITLE
feat: Add default, exec-based, startup probe to the deployment template

### DIFF
--- a/templates.js
+++ b/templates.js
@@ -60,9 +60,9 @@ const deploymentTemplate = {
                         startupProbe: {
                             exec: {
                                 command: [
-                                    "sh",
-                                    "-c",
-                                    "curl -sf -o /dev/null -w '%{http_code}' http://localhost:2880/flowforge/ready | grep -qE '^(200|404)$' && exit 0 || exit 1"
+                                    'sh',
+                                    '-c',
+                                    'curl -sf -o /dev/null -w \'%{http_code}\' http://localhost:2880/flowforge/ready | grep -qE \'^(200|404)$\' && exit 0 || exit 1'
                                 ]
                             },
                             initialDelaySeconds: 5,


### PR DESCRIPTION
## Description

This pull request adds default startupProbe values for the Node-RED container.
In the presented approach, the startup probe invokes the `curl` command inside the container to query the `/flowforge/ready` endpoint on the management port and accepts both 200 and 404 HTTP statuses.
This approach allows enabling such configuration on the project containers created with `nr-launcher` version `2.23.1` and earlier.
Additionally, default startup probe:
* waits 5 seconds after container startup
* executes every 2 seconds
* expects 1 successful response
* accepts 450 consecutive failures before restarting the pod

## Related Issue(s)

https://github.com/FlowFuse/driver-k8s/issues/233

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

