### PR TITLE
feat: Add possibility to specify custom scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ AWS EKS specific annotation for ALB Ingress. or `openshift` to allow running on 
 - `podSecurityContext` Settings linked to the [security context of the pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
 - `containerSecurityContext` Settings linked to the [security context of the container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
 - `service.type` Type of service to create for the editor (allowed `ClusterIP` or `NodePort`, default `ClusterIP`)
+- `schedulerName` name of the custom Kubernetes scheduler to use for Project Pods and MQTT agent Pods (default not set, uses default Kubernetes scheduler)
 
 Expects to pick up K8s credentials from the environment
 

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -80,6 +80,10 @@ const createDeployment = async (project, options) => {
     localPod.metadata.labels.name = project.safeName
     localPod.spec.serviceAccount = process.env.EDITOR_SERVICE_ACCOUNT
 
+    if (this._schedulerName) {
+        localPod.spec.schedulerName = this._schedulerName
+    }
+
     if (stack.container) {
         localPod.spec.containers[0].image = stack.container
     } else {
@@ -648,6 +652,10 @@ const createMQTTTopicAgent = async (broker) => {
         localPod.spec.nodeSelector = this._app.config.driver.options.projectSelector
     }
 
+    if (this._schedulerName) {
+        localPod.spec.schedulerName = this._schedulerName
+    }
+
     localPod.metadata.name = `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`
     localPod.metadata.labels = {
         name: `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${broker.hashid.toLowerCase()}`,
@@ -709,6 +717,7 @@ module.exports = {
         this._projectIngressAnnotations = this._app.config.driver.options?.projectIngressAnnotations
         this._logPassthrough = this._app.config.driver.options?.logPassthrough || false
         this._cloudProvider = this._app.config.driver.options?.cloudProvider
+        this._schedulerName = this._app.config.driver.options?.schedulerName
         if (this._app.config.driver.options?.customHostname?.enabled) {
             this._app.log.info('[k8s] Enabling Custom Hostname Support')
             this._customHostname = this._app.config.driver.options?.customHostname


### PR DESCRIPTION
## Description

This pull request extends the kubernetes driver by adding a possibility to configure custom scheduler for project deployments via `schedulerName` driver configuration parameter.

## Related Issue(s)

https://github.com/FlowFuse/driver-k8s/issues/274

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

