### PR TITLE
HA Instance pipeline rolling deploy

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -1374,16 +1374,24 @@ module.exports = {
             // need to return early otherwise front end will timeout
             process.nextTick(async () => {
                 for (const address in endpoints) {
-                    await got.post(`http://${endpoints[address]}:2880/flowforge/command`, {
-                        json: {
-                            cmd: 'restart'
-                        }
-                    })
+                    try {
+                        await got.post(`http://${endpoints[address]}:2880/flowforge/command`, {
+                            json: {
+                                cmd: 'restart'
+                            },
+                            timeout: {
+                                request: 1000
+                            }
+                        })
+                    } catch (err) {
+                        // need to make sure we catch all errors in nextTick
+                        console.error('Error sending restart command to replica', err)
+                    }
                     try {
                         // need to wait for each instance to come back
                         await waitForInstanceRunning(endpoints[address])
                     } catch (err) {
-                        console.error(err)
+                        console.error('Error waiting on replica to restart', err)
                     }
                 }
             })


### PR DESCRIPTION
fixes FlowFuse/flowfuse#5871
## Description

<!-- Describe your changes in detail -->
Makes the `app.containers.restartFlows()` call wait for the first replica to finish restarting before restarting the second.

This should ensure there is always a replica running when new flows are pushed or the the instance is restarted from the overview page.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/flowfuse#5871

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

