### PR TITLE
fix: Remove redundant poll loops for created Ingress, Service and Deployment resources

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -508,25 +508,6 @@ const createProject = async (project, options) => {
         }
     }
 
-    await new Promise((resolve, reject) => {
-        let counter = 0
-        const pollInterval = setInterval(async () => {
-            try {
-                await this._k8sAppApi.readNamespacedDeployment({ name: project.safeName, namespace: this._namespace })
-                clearInterval(pollInterval)
-                resolve()
-            } catch (err) {
-                // hmm
-                counter++
-                if (counter > this._k8sRetries) {
-                    clearInterval(pollInterval)
-                    this._app.log.error(`[k8s] Instance ${project.id} - timeout waiting for Deployment`)
-                    reject(new Error('Timed out to creating Deployment'))
-                }
-            }
-        }, this._k8sDelay)
-    })
-
     try {
         await this._k8sApi.createNamespacedService({ namespace, body: localService })
     } catch (err) {
@@ -539,25 +520,6 @@ const createProject = async (project, options) => {
             }
         }
     }
-
-    const prefix = project.safeName.match(/^[0-9]/) ? 'srv-' : ''
-    await new Promise((resolve, reject) => {
-        let counter = 0
-        const pollInterval = setInterval(async () => {
-            try {
-                await this._k8sApi.readNamespacedService({ name: prefix + project.safeName, namespace: this._namespace })
-                clearInterval(pollInterval)
-                resolve()
-            } catch (err) {
-                counter++
-                if (counter > this._k8sRetries) {
-                    clearInterval(pollInterval)
-                    this._app.log.error(`[k8s] Instance ${project.id} - timeout waiting for Service`)
-                    reject(new Error('Timed out to creating Service'))
-                }
-            }
-        }, this._k8sDelay)
-    })
 
     try {
         await this._k8sNetApi.createNamespacedIngress({ namespace, body: localIngress })
@@ -589,24 +551,6 @@ const createProject = async (project, options) => {
             }
         }
     }
-
-    await new Promise((resolve, reject) => {
-        let counter = 0
-        const pollInterval = setInterval(async () => {
-            try {
-                await this._k8sNetApi.readNamespacedIngress({ name: project.safeName, namespace: this._namespace })
-                clearInterval(pollInterval)
-                resolve()
-            } catch (err) {
-                counter++
-                if (counter > this._k8sRetries) {
-                    clearInterval(pollInterval)
-                    this._app.log.error(`[k8s] Instance ${project.id} - timeout waiting for Ingress`)
-                    reject(new Error('Timed out to creating Ingress'))
-                }
-            }
-        }, this._k8sDelay)
-    })
 
     await project.updateSetting('k8sType', 'deployment')
 


### PR DESCRIPTION
## Description

This pull request removes three `setInterval` poll loops that follow creation of `Deployment` , `Service` and `Ingress` resources.

Each loop polled the Kubernetes API until the resource was found, treating this as a prerequisite before proceeding. However, a successful resource create call already guarantees the resource is written to the API server and immediately readable - there is no inconsistency possibility. The loops resolved on their very first tick in every normal case, providing no correctness value.

Removing them reduces the number of Kubernetes API calls per project creation from up to 8 (5 creates + 3 reads) down to 5.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

