### PR TITLE
Mqtt schema deployment

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -682,11 +682,14 @@ const createMQTTTopicAgent = async (broker) => {
     }
 
     localPod.metadata.name = `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`
+    localDeployment.metadata.name = localPod.metadata.name
     localPod.metadata.labels = {
         name: `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${broker.hashid.toLowerCase()}`,
         team: broker.Team.hashid,
         broker: agent ? 'team-broker' : broker.hashid
     }
+    localDeployment.metadata.labels = localPod.metadata.labels
+    localDeployment.spec.selector.matchLabels.name = localPod.metadata.name
     localService.metadata.name = `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`
     localService.metadata.labels = {
         team: broker.Team.hashid,

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -930,15 +930,29 @@ module.exports = {
                 for (const broker of brokers) {
                     const agent = broker.constructor.name === 'TeamBrokerAgent'
                     if (broker.Team && broker.state === 'running') {
+                        const found = false
                         try {
                             this._app.log.info(`[k8s] Testing MQTT Agent ${agent ? 'team-broker' : broker.hashid} in ${namespace} pod exists`)
                             this._app.log.debug(`mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`)
                             await this._k8sApi.readNamespacedPodStatus({ name: `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`, namespace })
                             this._app.log.info(`[k8s] MQTT Agent pod ${agent ? 'team-broker' : broker.hashid} in ${namespace} found`)
+                            found = true
                         } catch (err) {
-                            this._app.log.debug(`[k8s] MQTT Agent ${agent ? 'team-broker' : broker.hashid} - failed ${err.toString()}`)
-                            this._app.log.debug(`[k8s] MQTT Agent ${agent ? 'team-broker' : broker.hashid} - recreating pod`)
-                            await createMQTTTopicAgent(broker)
+                            // this._app.log.debug(`[k8s] MQTT Agent ${agent ? 'team-broker' : broker.hashid} - failed ${err.toString()}`)
+                            // this._app.log.debug(`[k8s] MQTT Agent ${agent ? 'team-broker' : broker.hashid} - recreating`)
+                            //await createMQTTTopicAgent(broker)
+                        }
+                        if (!found) {
+                            try {
+                                this._app.log.info(`[k8s] Testing MQTT Agent ${agent ? 'team-broker' : broker.hashid} in ${namespace} deployment exists`)
+                                // await this._k8sApi.readNamespacedPodStatus({ name: `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`, namespace })
+                                await this._k8sAppApi.readNamespacedDeployment({ name: `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`, namespace })
+                                this._app.log.info(`[k8s] MQTT Agent pod ${agent ? 'team-broker' : broker.hashid} in ${namespace} found`)
+                            } catch (err) {
+                                this._app.log.debug(`[k8s] MQTT Agent ${agent ? 'team-broker' : broker.hashid} - failed ${err.toString()}`)
+                                this._app.log.debug(`[k8s] MQTT Agent ${agent ? 'team-broker' : broker.hashid} - recreating`)
+                                await createMQTTTopicAgent(broker)
+                            }
                         }
                     }
                 }
@@ -1576,7 +1590,24 @@ module.exports = {
         const agent = broker.constructor.name === 'TeamBrokerAgent'
         try {
             await this._k8sApi.deleteNamespacedService({ name: `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`, namespace: this._namespace })
-            await this._k8sApi.deleteNamespacedPod({ name: `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`, namespace: this._namespace })
+            try {
+                await this._k8sApi.deleteNamespacedPod({ name: `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`, namespace: this._namespace })
+            } catch (err) {
+                if (err.code === 404 || err.response?.statusCode === 404) {
+                    // not found
+                } else {
+                    throw err
+                }
+            }
+            try {
+                await this._k8sAppApi.deleteNamespacedDeployment({ name: `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`, namespace: this._namespace })
+            } catch (err) {
+                if (err.code === 404 || err.response?.statusCode === 404) {
+                    // not found
+                } else {
+                    throw err
+                }
+            }
         } catch (err) {
             this._app.log.error(`[k8s] Error deleting MQTT Agent ${agent ? 'team-broker' : broker.hashid}: ${err.toString()} ${err.code}`)
         }

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -11,7 +11,6 @@ const {
     ingressTemplate,
     customIngressTemplate,
     persistentVolumeClaimTemplate,
-    mqttSchemaAgentPodTemplate,
     mqttSchemaAgentDeploymentTemplate,
     mqttSchemaAgentServiceTemplate
 } = require('./templates.js')
@@ -933,7 +932,7 @@ module.exports = {
                 for (const broker of brokers) {
                     const agent = broker.constructor.name === 'TeamBrokerAgent'
                     if (broker.Team && broker.state === 'running') {
-                        const found = false
+                        let found = false
                         try {
                             this._app.log.info(`[k8s] Testing MQTT Agent ${agent ? 'team-broker' : broker.hashid} in ${namespace} pod exists`)
                             this._app.log.debug(`mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`)
@@ -943,7 +942,6 @@ module.exports = {
                         } catch (err) {
                             // this._app.log.debug(`[k8s] MQTT Agent ${agent ? 'team-broker' : broker.hashid} - failed ${err.toString()}`)
                             // this._app.log.debug(`[k8s] MQTT Agent ${agent ? 'team-broker' : broker.hashid} - recreating`)
-                            //await createMQTTTopicAgent(broker)
                         }
                         if (!found) {
                             try {

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -12,6 +12,7 @@ const {
     customIngressTemplate,
     persistentVolumeClaimTemplate,
     mqttSchemaAgentPodTemplate,
+    mqttSchemaAgentDeploymentTemplate,
     mqttSchemaAgentServiceTemplate
 } = require('./templates.js')
 
@@ -655,7 +656,9 @@ const getStaticFileUrl = async (instance, filePath) => {
 const createMQTTTopicAgent = async (broker) => {
     const agent = broker.constructor.name === 'TeamBrokerAgent'
     this._app.log.info(`[k8s] Starting MQTT Schema agent ${agent ? 'team-broker' : broker.hashid} for ${broker.Team.hashid}`)
-    const localPod = JSON.parse(JSON.stringify(mqttSchemaAgentPodTemplate))
+    const localDeployment = JSON.parse(JSON.stringify(mqttSchemaAgentDeploymentTemplate))
+    // const localPod = JSON.parse(JSON.stringify(mqttSchemaAgentPodTemplate))
+    const localPod = localDeployment.spec.template
     const localService = JSON.parse(JSON.stringify(mqttSchemaAgentServiceTemplate))
 
     const namespace = this._app.config.driver.options.projectNamespace || 'flowforge'

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -686,7 +686,7 @@ const createMQTTTopicAgent = async (broker) => {
         name: `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`,
         team: broker.Team.hashid,
         broker: agent ? 'team-broker' : broker.hashid,
-
+        mqttSchemaAgent: 'true'
     }
     localDeployment.metadata.labels = localPod.metadata.labels
     localDeployment.spec.selector.matchLabels.name = localPod.metadata.name

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -707,11 +707,12 @@ const createMQTTTopicAgent = async (broker) => {
     // TODO remove registry entry
     localPod.spec.containers[0].image = this._app.config.driver.options?.mqttSchemaContainer || `${this._app.config.driver.options.registry ? this._app.config.driver.options.registry + '/' : ''}flowfuse/mqtt-schema-agent`
 
-    // console.log(JSON.stringify(localPod,null,2))
+    // console.log(JSON.stringify(localDeployment,null,2))
     // console.log(JSON.stringify(localService,null,2))
     try {
         console.debug(namespace, localPod.metadata.name)
-        await this._k8sApi.createNamespacedPod({ namespace, body: localPod })
+        // await this._k8sApi.createNamespacedPod({ namespace, body: localPod })
+        await this._k8sAppApi.createNamespacedDeployment({ namespace, body: localDeployment })
         await this._k8sApi.createNamespacedService({ namespace, body: localService })
     } catch (err) {
         this._app.log.error(`[k8s] Problem creating MQTT Agent ${agent ? 'team-broker' : broker.hashid} in ${namespace} - ${err.toString()} ${err.stack}`)

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -948,7 +948,7 @@ module.exports = {
                                 this._app.log.info(`[k8s] Testing MQTT Agent ${agent ? 'team-broker' : broker.hashid} in ${namespace} deployment exists`)
                                 // await this._k8sApi.readNamespacedPodStatus({ name: `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`, namespace })
                                 await this._k8sAppApi.readNamespacedDeployment({ name: `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`, namespace })
-                                this._app.log.info(`[k8s] MQTT Agent pod ${agent ? 'team-broker' : broker.hashid} in ${namespace} found`)
+                                this._app.log.info(`[k8s] MQTT Agent deployment ${agent ? 'team-broker' : broker.hashid} in ${namespace} found`)
                             } catch (err) {
                                 this._app.log.debug(`[k8s] MQTT Agent ${agent ? 'team-broker' : broker.hashid} - failed ${err.toString()}`)
                                 this._app.log.debug(`[k8s] MQTT Agent ${agent ? 'team-broker' : broker.hashid} - recreating`)

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -683,16 +683,18 @@ const createMQTTTopicAgent = async (broker) => {
     localPod.metadata.name = `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`
     localDeployment.metadata.name = localPod.metadata.name
     localPod.metadata.labels = {
-        name: `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${broker.hashid.toLowerCase()}`,
+        name: `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`,
         team: broker.Team.hashid,
-        broker: agent ? 'team-broker' : broker.hashid
+        broker: agent ? 'team-broker' : broker.hashid,
+
     }
     localDeployment.metadata.labels = localPod.metadata.labels
     localDeployment.spec.selector.matchLabels.name = localPod.metadata.name
     localService.metadata.name = `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`
     localService.metadata.labels = {
         team: broker.Team.hashid,
-        broker: agent ? 'team-broker' : broker.hashid
+        broker: agent ? 'team-broker' : broker.hashid,
+        mqttSchemaAgent: 'true'
     }
     if (this._app.config.driver.options?.projectLabels) {
         localPod.metadata.labels = {

--- a/templates.js
+++ b/templates.js
@@ -1,5 +1,3 @@
-const { resources } = require("./kubernetes")
-
 const deploymentTemplate = {
     apiVersion: 'apps/v1',
     kind: 'Deployment',

--- a/templates.js
+++ b/templates.js
@@ -223,7 +223,7 @@ const mqttSchemaAgentDeploymentTemplate = {
                 }
             },
             spec: {
-                constainers: [
+                containers: [
                     {
                         name: 'mqtt-schema-agent',
                         // image: 'flowfuse/mqtt-schema-agent',

--- a/templates.js
+++ b/templates.js
@@ -1,3 +1,5 @@
+const { resources } = require("./kubernetes")
+
 const deploymentTemplate = {
     apiVersion: 'apps/v1',
     kind: 'Deployment',
@@ -199,6 +201,61 @@ const mqttSchemaAgentPodTemplate = {
     enableServiceLinks: false
 }
 
+const mqttSchemaAgentDeploymentTemplate = {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+        labels: {
+            mqttSchemaAgent: 'true'
+        }
+    },
+    spec: {
+        replicas: 1,
+        selector: {
+            matchLabels: {
+
+            }
+        },
+        template: {
+            metadata: {
+                labels: {
+                    mqttSchemaAgent: 'true'
+                }
+            },
+            spec: {
+                constainers: [
+                    {
+                        name: 'mqtt-schema-agent',
+                        // image: 'flowfuse/mqtt-schema-agent',
+                        imagePullPolicy: 'Always',
+                        securityContext: {
+                            allowPrivilegeEscalation: false
+                        },
+                        env: [
+                            { name: 'TZ', value: 'Europe/London' }
+                        ],
+                        ports: [
+                            { name: 'web', containerPort: 3500, protocol: 'TCP' }
+                        ],
+                        resources: {
+                            requests: {
+                                // 10th of a core
+                                cpu: '100m',
+                                memory: '128Mi'
+                            },
+                            limits: {
+                                cpu: '100m',
+                                memory: '128Mi'
+                            }
+                        }
+                    }
+                ]
+            },
+            enableServiceLinks: false
+        }
+    }
+}
+
 const mqttSchemaAgentServiceTemplate = {
     apiVersion: 'v1',
     kind: 'Service',
@@ -223,5 +280,6 @@ module.exports = {
     customIngressTemplate,
     persistentVolumeClaimTemplate,
     mqttSchemaAgentPodTemplate,
+    mqttSchemaAgentDeploymentTemplate,
     mqttSchemaAgentServiceTemplate
 }

--- a/templates.js
+++ b/templates.js
@@ -11,6 +11,7 @@ const deploymentTemplate = {
     },
     spec: {
         replicas: 1,
+        revisionHistoryLimit: 3,
         selector: {
             matchLabels: {
                 // app: "k8s-client-test-deployment"
@@ -161,54 +162,15 @@ const persistentVolumeClaimTemplate = {
     }
 }
 
-const mqttSchemaAgentPodTemplate = {
-    apiVersion: 'v1',
-    kind: 'Pod',
-    metadata: {
-
-    },
-    spec: {
-        containers: [
-            {
-                name: 'mqtt-schema-agent',
-                // image: 'flowfuse/mqtt-schema-agent',
-                imagePullPolicy: 'Always',
-                securityContext: {
-                    allowPrivilegeEscalation: false
-                },
-                env: [
-                    { name: 'TZ', value: 'Europe/London' }
-                ],
-                ports: [
-                    { name: 'web', containerPort: 3500, protocol: 'TCP' }
-                ],
-                resources: {
-                    requests: {
-                        // 10th of a core
-                        cpu: '100m',
-                        memory: '128Mi'
-                    },
-                    limits: {
-                        cpu: '100m',
-                        memory: '128Mi'
-                    }
-                }
-            }
-        ]
-    },
-    enableServiceLinks: false
-}
-
 const mqttSchemaAgentDeploymentTemplate = {
     apiVersion: 'apps/v1',
     kind: 'Deployment',
     metadata: {
-        labels: {
-            mqttSchemaAgent: 'true'
-        }
+        labels: { }
     },
     spec: {
         replicas: 1,
+        revisionHistoryLimit: 3,
         selector: {
             matchLabels: {
 
@@ -216,9 +178,7 @@ const mqttSchemaAgentDeploymentTemplate = {
         },
         template: {
             metadata: {
-                labels: {
-                    mqttSchemaAgent: 'true'
-                }
+                labels: { }
             },
             spec: {
                 containers: [
@@ -277,7 +237,6 @@ module.exports = {
     ingressTemplate,
     customIngressTemplate,
     persistentVolumeClaimTemplate,
-    mqttSchemaAgentPodTemplate,
     mqttSchemaAgentDeploymentTemplate,
     mqttSchemaAgentServiceTemplate
 }


### PR DESCRIPTION
fixes #337 
## Description

<!-- Describe your changes in detail -->
This moves to using Deployments for mqtt-schema-agent over raw Pods. This means K8s scheduler will automatically restart when moving between Nodes.

This makes K8s upgrades easier.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

#337 